### PR TITLE
refactor AWS auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="terraform-worker",
-    version="0.2.0",
+    version="0.3.0",
     packages=find_packages(exclude=["tests*"]),
     author="Richard Maynard",
     author_email="richard.maynard@gmail.com",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,23 +2,23 @@ import os
 
 import pytest
 
-import worker.main
+import tfworker.main
 
 
 class TestMain:
     def test_state_add_arg(self):
-        state = worker.main.State()
+        state = tfworker.main.State()
         state.add_arg("a", 1)
         assert state.args.a == 1
 
     def test_state_add_args(self):
-        state = worker.main.State()
+        state = tfworker.main.State()
         state.add_args({"a": 1, "b": "two"})
         assert state.args.a == 1
         assert state.args.b == "two"
 
     def test_state_init(self):
-        state = worker.main.State(args={"a": 1, "b": "two"})
+        state = tfworker.main.State(args={"a": 1, "b": "two"})
         assert state.args.a == 1
         assert state.args.b == "two"
 
@@ -63,7 +63,7 @@ class TestMain:
         ],
     )
     def test_run_pipe_exec(self, commands, exit_code, cwd, stdin, stdout, stderr):
-        (return_exit_code, return_stdout, return_stderr) = worker.main.pipe_exec(
+        (return_exit_code, return_stdout, return_stderr) = tfworker.main.pipe_exec(
             commands, cwd=cwd, stdin=stdin
         )
 
@@ -83,4 +83,4 @@ class TestMain:
         ],
     )
     def test_replace_vars(self, state, var, expected):
-        assert worker.main.replace_vars(var, state.args) == expected
+        assert tfworker.main.replace_vars(var, state.args) == expected

--- a/tfworker/terraform.py
+++ b/tfworker/terraform.py
@@ -187,6 +187,7 @@ def make_vars(section, single, base=None):
             matched_type = True
         if not matched_type:
             item_vars[k] = v
+
     return item_vars
 
 


### PR DESCRIPTION
- increment PIP release version (will publish once changes accepted)
- support assumed identities (roles)
- support standard boto3 profile/configuration (~/.aws/config ~/.aws/credentials)
- support selection of boto3 profiles (via cli or environment var)

Order of auth precedence: 
- credentials passed on command line (boo)
- credentials passed via environment variable
- credentials in boto3 configurations 

session credentials will be acquired by the worker if they are not passed, it will use credentials from above sources to generate session credentials which will be used for all operations

if a role is passed, credentials from above sources (including session credentials) will be used to get assumed role credentials, which will then be used for all operations.