### PR TITLE
add support for execution hooks

### DIFF
--- a/tfworker/terraform.py
+++ b/tfworker/terraform.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import base64
+import copy
 import glob
+import json
+import os
+import re
 import shutil
 import sys
 import urllib
 import zipfile
-import copy
 
 from pathlib import Path
 
@@ -33,6 +36,10 @@ class TerraformError(Exception):
 
 
 class PlanChange(Exception):
+    pass
+
+
+class HookError(Exception):
     pass
 
 
@@ -93,7 +100,7 @@ def prep_modules(src, dst):
 def prep_def(name, definition, all_defs, temp_dir, repo_path, deployment, args):
     """ prepare the definitions for running """
     repo = Path("{}/{}".format(repo_path, definition["path"]).replace("//", "/"))
-    target = Path("{}/definitions/test/{}".format(temp_dir, name).replace("//", "/"))
+    target = Path("{}/definitions/{}".format(temp_dir, name).replace("//", "/"))
     target.mkdir(parents=True, exist_ok=True)
 
     if not repo.exists():
@@ -130,6 +137,8 @@ def prep_def(name, definition, all_defs, temp_dir, repo_path, deployment, args):
         shutil.copytree(
             "{}/scripts".format(str(repo)), "{}/scripts".format(str(target))
         )
+    if os.path.isdir(str(repo) + "/hooks".replace("//", "/")):
+        shutil.copytree("{}/hooks".format(str(repo)), "{}/hooks".format(str(target)))
     if os.path.isdir(str(repo) + "/repos".replace("//", "/")):
         shutil.copytree("{}/repos".format(str(repo)), "{}/repos".format(str(target)))
 
@@ -254,13 +263,14 @@ def render_providers(providers, args):
 def run(
     name,
     temp_dir,
-    terrform_path,
+    terraform_path,
     command,
     key_id,
     key_secret,
     key_token=None,
     debug=False,
     plan_action="apply",
+    b64_encode=False,
 ):
     """Run terraform."""
     params = {
@@ -280,7 +290,7 @@ def run(
         env["AWS_SESSION_TOKEN"] = key_token
     env["TF_PLUGIN_CACHE_DIR"] = "{}/terraform-plugins".format(temp_dir)
 
-    working_dir = "{}/definitions/test/{}".format(temp_dir, name)
+    working_dir = "{}/definitions/{}".format(temp_dir, name)
     command_params = params.get(command)
     if not command_params:
         raise ValueError(
@@ -289,8 +299,36 @@ def run(
             )
         )
 
+    # only execute hooks for plan/destroy
+    try:
+        if check_hooks("pre", working_dir, command) and command in ["apply", "destroy"]:
+            # pre exec hooks
+            # want to pass remotes
+            # want to pass tf_vars
+            click.secho(
+                "found pre-{} hook script for definition {}, executing ".format(
+                    command, name
+                ),
+                fg="yellow",
+            )
+            hook_exec(
+                "pre",
+                command,
+                name,
+                working_dir,
+                env,
+                terraform_path,
+                debug=debug,
+                b64_encode=b64_encode,
+            )
+    except HookError as e:
+        click.secho(
+            "hook execution error on definition {}: {}".format(name, e), fg="red"
+        )
+        raise SystemExit(1)
+
     (exit_code, stdout, stderr) = pipe_exec(
-        "{} {} {}".format(terrform_path, command, command_params),
+        "{} {} {}".format(terraform_path, command, command_params),
         cwd=working_dir,
         env=env,
     )
@@ -313,4 +351,176 @@ def run(
     if exit_code:
         raise TerraformError
 
+    # only execute hooks for plan/destroy
+    try:
+        if check_hooks("post", working_dir, command) and command in [
+            "apply",
+            "destroy",
+        ]:
+            # post exec hooks
+            # want to pass remotes
+            # want to pass tf_vars
+            click.secho(
+                "found post-{} hook script for definition {}, executing ".format(
+                    command, name
+                ),
+                fg="yellow",
+            )
+            # hook_exec("what", "args", "are", "needed")
+    except HookError as e:
+        click.secho(
+            "hook execution error on definition {}: {}".format(name, e), fg="red"
+        )
+        raise SystemExit(1)
     return True
+
+
+def check_hooks(phase, working_dir, command):
+    """
+    check_hooks determines if a hook exists for a given operation/definition
+    """
+    hook_dir = "{}/hooks".format(working_dir)
+    if not os.path.isdir(hook_dir):
+        # there is no hooks dir
+        return False
+    for f in os.listdir(hook_dir):
+        if os.path.splitext(f)[0] == "{}_{}".format(phase, command):
+            if os.access("{}/{}".format(hook_dir, f), os.X_OK):
+                return True
+            else:
+                raise HookError(
+                    "{}/{} exists, but is not executable!".format(hook_dir, f)
+                )
+    return False
+
+
+def hook_exec(
+    phase,
+    command,
+    name,
+    working_dir,
+    env,
+    terraform_path,
+    debug=False,
+    b64_encode=False,
+):
+    """
+    hook_exec executes a hook script.
+
+    Before execution it sets up the environment to make all terraform and remote
+    state variables available to the hook via environment vars
+    """
+
+    key_replace_items = {
+        " ": "",
+        '"': "",
+        "-": "_",
+        ".": "_",
+    }
+    val_replace_items = {
+        " ": "",
+        '"': "",
+    }
+    local_env = env.copy()
+    hook_dir = "{}/hooks".format(working_dir)
+    hook_script = None
+
+    for f in os.listdir(hook_dir):
+        # this file format is specifically structured by the prep_def function
+        if os.path.splitext(f)[0] == "{}_{}".format(phase, command):
+            hook_script = "{}/{}".format(hook_dir, f)
+    # this should never have been called if the hook script didn't exist...
+    if hook_script is None:
+        raise HookError("hook script missing from {}".format(hook_dir))
+
+    # populate environment with terraform vars
+    if os.path.isfile("{}/worker-locals.tf".format(working_dir)):
+        # I'm sorry.
+        r = re.compile(
+            r"\s*(?P<item>\w+)\s*\=.+data\.terraform_remote_state\.(?P<state>\w+)\.outputs\.(?P<state_item>\w+)\s*"
+        )
+
+        with open("{}/worker-locals.tf".format(working_dir)) as f:
+            for line in f:
+                m = r.match(line)
+                if m:
+                    item = m.group("item")
+                    state = m.group("state")
+                    state_item = m.group("state_item")
+                else:
+                    continue
+
+                state_value = get_state_item(
+                    working_dir, env, terraform_path, state, state_item
+                )
+
+                if b64_encode:
+                    state_value = base64.b64encode(state_value.encode("utf-8")).decode()
+
+                local_env["TF_REMOTE_{}_{}".format(state, item).upper()] = state_value
+
+    # populate environment with terraform remotes
+    if os.path.isfile("{}/worker.auto.tfvars".format(working_dir)):
+        with open("{}/worker.auto.tfvars".format(working_dir)) as f:
+            for line in f:
+                tf_var = line.split("=")
+
+                # strip bad names out for env var settings
+                for k, v in key_replace_items.items():
+                    tf_var[0] = tf_var[0].replace(k, v)
+
+                for k, v in val_replace_items.items():
+                    tf_var[1] = tf_var[1].replace(k, v)
+
+                if b64_encode:
+                    tf_var[1] = base64.b64encode(tf_var[1].encode("utf-8")).decode()
+
+                local_env["TF_VAR_{}".format(tf_var[0].upper())] = tf_var[1]
+    else:
+        click.secho("{}/worker.auto.tfvars not found!".format(working_dir), fg="red")
+
+    # execute the hook
+    (exit_code, stdout, stderr) = pipe_exec(
+        "{} {} {}".format(hook_script, phase, command), cwd=hook_dir, env=local_env,
+    )
+
+    # handle output from hook_script
+    if debug:
+        click.secho("exit code: {}".format(exit_code), fg="blue")
+        for line in stdout.decode().splitlines():
+            click.secho("stdout: {}".format(line), fg="blue")
+        for line in stderr.decode().splitlines():
+            click.secho("stderr: {}".format(line), fg="red")
+
+    if exit_code != 0:
+        raise HookError("hook script {}")
+
+    pass
+
+
+def get_state_item(working_dir, env, terraform_path, state, item):
+    """
+    get_state_item returns json encoded output from a terraform remote state
+    """
+    base_dir, _ = os.path.split(working_dir)
+    (exit_code, stdout, stderr) = pipe_exec(
+        "{} output -json -no-color {}".format(terraform_path, item),
+        cwd="{}/{}".format(base_dir, state),
+        env=env,
+    )
+
+    if exit_code != 0:
+        raise HookError(
+            "Error reading remote state item {}.{}, details: {}".format(
+                state, item, stderr
+            )
+        )
+
+    if stdout is None:
+        raise HookError(
+            "Remote state item {}.{} is empty; This is completely unexpected, failing...".format(
+                state, item
+            )
+        )
+    json_output = json.loads(stdout)
+    return json.dumps(json_output, indent=None, separators=(",", ":"))


### PR DESCRIPTION
**New Features:**
plan and destroy support both pre, and post execution hooks. There are
many times where terraforms `execute` statement are not sufficient, and
it will -always- trigger a change which is undesirable.

This new feature works by looking in the `hooks` directory in a
definition. If the hooks directory exists, and contains scripts that are
executable it will run them. The scripts -must- be named in accordance
to the pattern below:

./hooks/pre_apply.*
./hooks/post_apply.*
./hooks/pre_destroy.*
./hooks/post_destroy.*

Any file extension is supported, as is no file extension.

This feature also provides an added advantage to the scripts in that it
puts all terraform variables defined in the worker configuration, and
all remote variables within reach of the script. The following
environment variables are set:

TF_VAR_<variable_name>=<variable_value>
TF_REMOTE_<definition_name>_<variable_name>=<remote state value>

In addition two arguments are passed to the scripts, phase (pre/post) and
command (apply/destroy). This would allow a single script with proper 
symlinks from the other names to handle all of the logic instead of needing
to create specific scripts for different phases/operations.

**BugFix -- BREAKING **
The worker was previously appending a path named `test` into the working
definition directory structure, this was causing references to modules to be
in accurate if supplied as a relative path, this means that before one might use:
../../../module-name  as the module source, when the actual path relative 
to the definition was ../../module-name, this bug has been fixed, but will require
updating any definitions that were relying on the bug behavior to be fixed.

**Extra CLI Options for `terraform` command:**
--force-apply: run terraform apply even if plan doesn't change, will
allow hooks to be force triggered if they are desired even without
change
--b64-encode-hook-values: this causes the worker to base64 encode all
terraform variables and state values that it sets in the hook execution
environment, this could be useful for handling complex terraform data
type outputs