### PR TITLE
add support for code commit sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "terraform-worker"
-version = "0.10.5"
+version = "0.10.6"
 description = "An orchestration tool for Terraform"
 authors = ["Richard Maynard <richard.maynard@objectrocket.com>"]
 packages = [

--- a/tests/util/test_copier.py
+++ b/tests/util/test_copier.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 import shutil
 from typing import Tuple
 from unittest import mock
@@ -78,7 +79,7 @@ def mock_pipe_exec_type_match(cmd: str) -> Tuple[int, str, str]:
 
 def mock_pipe_exec_clone(cmd: str, cwd: str) -> Tuple[int, str, str]:
     """ a mock function to copy files and imitate a git clone """
-    tokens = cmd.split(" ")
+    tokens = re.split(r'\s+', cmd)
     assert os.path.isdir(tokens[2])
     shutil.copytree(tokens[2], cwd, dirs_exist_ok=True)
     return (0, "", "")
@@ -218,7 +219,7 @@ class TestGitCopier:
             """ test a succeeding condition, extra options passed """
             spath = f"{request.config.rootdir}/tests/fixtures/definitions"
             c = GitCopier(source=spath, destination=dpath, conflicts=[])
-            c.copy(branch="foo", sub_path="test_a")
+            c.copy(branch="foo", sub_path="test_a", git_cmd="git", git_args="", reset_repo=True)
             assert (
                 mocked.call_args.args[0]
                 == f"git clone {spath} --branch foo --single-branch ./"

--- a/tfworker/util/copier.py
+++ b/tfworker/util/copier.py
@@ -139,19 +139,29 @@ class GitCopier(Copier):
         """ copy clones a remote git repo, and puts the requested files into the destination """
         dest = self.get_destination(**kwargs)
         branch = "master"
+        git_cmd = "git"
+        git_args = ""
+        reset_repo = False
 
-        if "branch" in kwargs:
-            branch = kwargs["branch"]
         if "sub_path" in kwargs:
             sub_path = kwargs["sub_path"].strip("/")
         else:
             sub_path = ""
 
+        if "branch" in kwargs:
+            branch = kwargs["branch"]
+        if "git_cmd" in kwargs:
+            git_cmd = kwargs['git_cmd']
+        if "git_args" in kwargs:
+            git_args = kwargs['git_args']
+        if "reset_repo" in kwargs:
+            reset_repo = kwargs['reset_repo']
+
         self.make_temp()
         temp_path = f"{self._temp_dir}/{sub_path}"
 
         pipe_exec(
-            f"git clone {self._source} --branch {branch} --single-branch ./",
+            re.sub(r'\s+', ' ', f"{git_cmd} {git_args} clone {self._source} --branch {branch} --single-branch ./"),
             cwd=self._temp_dir,
         )
 
@@ -160,6 +170,9 @@ class GitCopier(Copier):
         except FileExistsError as e:
             self.clean_temp()
             raise e
+
+        if reset_repo:
+            self.repo_clean(f"{temp_path}")
 
         shutil.copytree(temp_path, dest, dirs_exist_ok=True)
         self.clean_temp()
@@ -186,6 +199,15 @@ class GitCopier(Copier):
             shutil.rmtree(self._temp_dir, ignore_errors=True)
             del self._temp_dir
 
+    @staticmethod
+    def repo_clean(p: str) -> None:
+        """ repo_clean removes git and github files from a clone before doing the copy """
+        for f in ['.git', '.github']:
+            try:
+                shutil.rmtree(f"{p}/{f}")
+            except FileNotFoundError:
+                pass
+
 
 @CopyFactory.register("fs")
 class FileSystemCopier(Copier):
@@ -199,7 +221,7 @@ class FileSystemCopier(Copier):
     def local_path(self):
         """ local_path returns a complete local file system path """
         if not hasattr(self, "_local_path"):
-            self._local_path = self.make_local_path(self.source, self._root_path)
+            self._local_path = self.make_local_path(self.source, self.root_path)
         return self._local_path
 
     @staticmethod


### PR DESCRIPTION
This adds addition options to the git copier to allow alternate git binaries to be used, and to allow git arguments to be passed. It also allows for optionally resetting the repo by removing .git and .github directories before copying. This is useful in the case of performing repository "mirrors"