### PR TITLE
changes for running in a reusable container

### DIFF
--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -65,7 +65,9 @@ class TestDefinitions:
         with open(basec.temp_dir + "/definitions/test/test.tf", "r") as reader:
             assert EXPECTED_TEST_BLOCK in reader.read()
         assert os.path.isfile(basec.temp_dir + "/definitions/test/worker_terraform.tf")
-        with open(basec.temp_dir + "/definitions/test/worker_terraform.tf", "r") as reader:
+        with open(
+            basec.temp_dir + "/definitions/test/worker_terraform.tf", "r"
+        ) as reader:
             tf_data = reader.read()
             assert expected_tf_block in tf_data
             for ep in expected_providers:

--- a/tfworker/commands/base.py
+++ b/tfworker/commands/base.py
@@ -67,8 +67,6 @@ class BaseCommand:
             rootc.args, deployment=deployment, **kwargs
         )
 
-        rootc.clean = kwargs.get("clean", True)
-
         self._providers = ProvidersCollection(
             rootc.providers_odict, self._authenticators, self._tf_version_major
         )
@@ -158,7 +156,6 @@ class BaseCommand:
             click.secho(f"unable to get terraform version\n{stderr}", fg="red")
             raise SystemExit(1)
         version = stdout.decode("UTF-8").split("\n")[0]
-        click.secho(f"{version}")
         version_search = re.search(r".*\s+v(\d+)\.(\d+)\.(\d+)", version)
         if version_search:
             click.secho(

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -65,9 +65,6 @@ class TerraformCommand(BaseCommand):
     def prep_modules(self):
         """Puts the modules sub directories into place."""
 
-        click.secho(
-            f"DEBUG: terraform_modules_dir: {self._terraform_modules_dir}", fg="red"
-        )
         if self._terraform_modules_dir:
             mod_source = self._terraform_modules_dir
             mod_path = pathlib.Path(mod_source)


### PR DESCRIPTION
- removed some errant debug messages
- moved "clean" option to root command instead of an option to `terraform`
- support using a specified directory instead of forcing a temp dir
- implement directory cleaning in a native pathlib way