### PR TITLE
Rm/inf 4935/improved jinjaing

### DIFF
--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -23,6 +23,7 @@ import click
 
 from tfworker import constants as const
 from tfworker.commands import CleanCommand, RootCommand, TerraformCommand
+from tfworker.commands.env import EnvCommand
 from tfworker.commands.root import get_platform
 from tfworker.commands.version import VersionCommand
 
@@ -326,6 +327,15 @@ def terraform(rootc, *args, **kwargs):
     tfc.prep_modules()
 
     tfc.exec()
+    sys.exit(0)
+
+
+@cli.command()
+@click.pass_obj
+def env(rootc, *args, **kwargs):
+    # provide environment variables from backend to configure shell environment
+    env = EnvCommand(rootc, *args, **kwargs)
+    env.exec()
     sys.exit(0)
 
 

--- a/tfworker/commands/env.py
+++ b/tfworker/commands/env.py
@@ -1,0 +1,24 @@
+import click
+
+from tfworker.authenticators import AuthenticatorsCollection
+
+
+class EnvCommand:
+    """
+    The env command translates the environment configuration that is used for the worker
+    into an output that can be `eval`'d by a shell. This will allow one to maintain the
+    same authentication options that the worker will use when running terraform when
+    executing commands against the rendered terraform definitions such as `terraform import`
+    """
+
+    def __init__(self, rootc, **kwargs):
+        # parse the configuration
+        rootc.load_config()
+
+        # initialize any authenticators
+        self._authenticators = AuthenticatorsCollection(rootc.args, deployment=None)
+
+    def exec(self):
+        for auth in self._authenticators:
+            for k, v in auth.env().items():
+                click.secho(f"export {k}={v}")

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -133,11 +133,6 @@ class TerraformCommand(BaseCommand):
 
             # check if a plan file for the given deployment/definition exists, if so
             # do not plan again
-            click.secho(
-                f"planning definition for {self._plan_for}: {definition.tag}",
-                fg="green",
-            )
-
             if plan_file is not None:
                 # if plan file is set, check if it exists, if it does do not plan again
                 if plan_file.exists():
@@ -147,6 +142,11 @@ class TerraformCommand(BaseCommand):
 
             if skip_plan is False and self._tf_plan:
                 # run terraform plan
+                click.secho(
+                    f"planning definition for {self._plan_for}: {definition.tag}",
+                    fg="green",
+                )
+
                 try:
                     self._run(
                         definition,


### PR DESCRIPTION
- fix exception handling surrounding existing files and undefined jinja vars
- in the configuration file parse a per definition key named: template_var
```
 ...
  definitions:
    example:
      path: ./example
      template_vars:
        module_version: 1.0
```