### PR TITLE
improve interactions with streaming output and enhance templating abilities

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1390,6 +1390,21 @@ files = [
 pytest = ">=3.2.5"
 
 [[package]]
+name = "pytest-timeout"
+version = "2.1.0"
+description = "pytest plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
+    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
+]
+
+[package.dependencies]
+pytest = ">=5.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -2020,4 +2035,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "04dfe20cb4f2282a65216b5b1a554f961d807817ca17838c966f8eee14cbc6d1"
+content-hash = "e68049eae1d997f4a8471d1f039e23073e663af1064562ea15aee2a1c5a827e4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ deepdiff = "^5.3.0"
 [tool.poetry.scripts]
 worker = 'tfworker.cli:cli'
 
+[tool.poetry.group.dev.dependencies]
+pytest-timeout = "2.1.0"
+
 [tool.pytest.ini_options]
 addopts = "--capture=sys --cov=tfworker --cov-report="
 

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -34,7 +34,13 @@ def does_not_raise():
     yield
 
 
-def mock_pipe_exec(args: str, stdin: str = None, cwd: str = None, env: list = None):
+def mock_pipe_exec(
+    args: str,
+    stdin: str = None,
+    cwd: str = None,
+    env: list = None,
+    stream_output: bool = False,
+):
     return (0, "".encode(), "".encode())
 
 

--- a/tests/util/test_system.py
+++ b/tests/util/test_system.py
@@ -36,13 +36,18 @@ def mock_tf_version(args: str):
 
 class TestUtilSystem:
     @pytest.mark.parametrize(
-        "commands, exit_code, cwd, stdin, stdout, stderr",
+        "commands, exit_code, cwd, stdin, stdout, stderr, stream_output",
         [
-            ("/usr/bin/env true", 0, None, None, "", ""),
-            ("/usr/bin/env false", 1, None, None, "", ""),
-            ("/bin/echo foo", 0, None, None, "foo", ""),
-            ("/usr/bin/env grep foo", 0, None, "foo", "foo", ""),
-            ("/bin/pwd", 0, "/tmp", None, "/tmp", ""),
+            ("/usr/bin/env true", 0, None, None, "", "", False),
+            ("/usr/bin/env true", 0, None, None, "", "", True),
+            ("/usr/bin/env false", 1, None, None, "", "", False),
+            ("/usr/bin/env false", 1, None, None, "", "", True),
+            ("/bin/echo foo", 0, None, None, "foo", "", False),
+            ("/bin/echo foo", 0, None, None, "foo", "", True),
+            ("/usr/bin/env grep foo", 0, None, "foo", "foo", "", False),
+            ("/usr/bin/env grep foo", 0, None, "foo", "foo", "", True),
+            ("/bin/pwd", 0, "/tmp", None, "/tmp", "", False),
+            ("/bin/pwd", 0, "/tmp", None, "/tmp", "", True),
             (
                 "/bin/cat /yisohwo0AhK8Ah ",
                 1,
@@ -50,15 +55,47 @@ class TestUtilSystem:
                 None,
                 "",
                 "/bin/cat: /yisohwo0AhK8Ah: No such file or directory",
+                False,
             ),
-            (["/bin/echo foo", "/usr/bin/env grep foo"], 0, None, None, "foo", ""),
-            (["/bin/echo foo", "/usr/bin/env grep bar"], 1, None, None, "", ""),
-            (["/bin/cat", "/usr/bin/env grep foo"], 0, None, "foo", "foo", ""),
+            (
+                "/bin/cat /yisohwo0AhK8Ah ",
+                1,
+                None,
+                None,
+                "",
+                "/bin/cat: /yisohwo0AhK8Ah: No such file or directory",
+                True,
+            ),
+            (
+                ["/bin/echo foo", "/usr/bin/env grep foo"],
+                0,
+                None,
+                None,
+                "foo",
+                "",
+                False,
+            ),
+            (
+                ["/bin/echo foo", "/usr/bin/env grep foo"],
+                0,
+                None,
+                None,
+                "foo",
+                "",
+                True,
+            ),
+            (["/bin/echo foo", "/usr/bin/env grep bar"], 1, None, None, "", "", False),
+            (["/bin/echo foo", "/usr/bin/env grep bar"], 1, None, None, "", "", True),
+            (["/bin/cat", "/usr/bin/env grep foo"], 0, None, "foo", "foo", "", False),
+            (["/bin/cat", "/usr/bin/env grep foo"], 0, None, "foo", "foo", "", True),
         ],
     )
-    def test_pipe_exec(self, commands, exit_code, cwd, stdin, stdout, stderr):
+    @pytest.mark.timeout(2)
+    def test_pipe_exec(
+        self, commands, exit_code, cwd, stdin, stdout, stderr, stream_output
+    ):
         (return_exit_code, return_stdout, return_stderr) = pipe_exec(
-            commands, cwd=cwd, stdin=stdin
+            commands, cwd=cwd, stdin=stdin, stream_output=stream_output
         )
 
         assert return_exit_code == exit_code

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -23,6 +23,7 @@ import click
 
 from tfworker import constants as const
 from tfworker.commands import CleanCommand, RootCommand, TerraformCommand
+from tfworker.commands.env import EnvCommand
 from tfworker.commands.root import get_platform
 from tfworker.commands.version import VersionCommand
 
@@ -326,6 +327,15 @@ def terraform(rootc, *args, **kwargs):
     tfc.prep_modules()
 
     tfc.exec()
+    sys.exit(0)
+
+
+@cli.command()
+@click.pass_obj
+def env(rootc, *args, **kwargs):
+    # provide environment variables from backend to configure shell environment
+    env = EnvCommand(rootc, *args, **kwargs)
+    env.exec()
     sys.exit(0)
 
 

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -311,6 +311,12 @@ def version():
     default=None,
     help="if provided this directory will be used as a cache for provider plugins",
 )
+@click.option(
+    "--stream-output/--no-stream-output",
+    help="stream the output from terraform command",
+    envvar="WORKER_STREAM_OUTPUT",
+    default=True,
+)
 @click.argument("deployment", envvar="WORKER_DEPLOYMENT", callback=validate_deployment)
 @click.pass_obj
 def terraform(rootc, *args, **kwargs):

--- a/tfworker/commands/env.py
+++ b/tfworker/commands/env.py
@@ -1,0 +1,24 @@
+import click
+
+from tfworker.authenticators import AuthenticatorsCollection
+
+
+class EnvCommand:
+    """
+    The env command translates the environment configuration that is used for the worker
+    into an output that can be `eval`'d by a shell. This will allow one to maintain the
+    same authentication options that the worker will use when running terraform when
+    executing commands against the rendered terraform definitions such as `terraform import`
+    """
+
+    def __init__(self, rootc, **kwargs):
+        # parse the configuration
+        rootc.load_config()
+
+        # initialize any authenticators
+        self._authenticators = AuthenticatorsCollection(rootc.args, deployment=None)
+
+    def exec(self):
+        for auth in self._authenticators:
+            for k, v in auth.env().items():
+                click.secho(f"export {k}={v}")

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -136,11 +136,6 @@ class TerraformCommand(BaseCommand):
 
             # check if a plan file for the given deployment/definition exists, if so
             # do not plan again
-            click.secho(
-                f"planning definition for {self._plan_for}: {definition.tag}",
-                fg="green",
-            )
-
             if plan_file is not None:
                 # if plan file is set, check if it exists, if it does do not plan again
                 if plan_file.exists():
@@ -150,6 +145,11 @@ class TerraformCommand(BaseCommand):
 
             if skip_plan is False and self._tf_plan:
                 # run terraform plan
+                click.secho(
+                    f"planning definition for {self._plan_for}: {definition.tag}",
+                    fg="green",
+                )
+
                 try:
                     self._run(
                         definition,

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -53,6 +53,9 @@ class TerraformCommand(BaseCommand):
         self._deployment = kwargs["deployment"]
         self._force = self._resolve_arg("force")
         self._show_output = self._resolve_arg("show_output")
+        # streaming doesn't allow for distinction between stderr and stdout, but allows
+        # terraform operations to be viewed before the process is completed
+        self._stream_output = self._resolve_arg("stream_output")
         self._terraform_modules_dir = self._resolve_arg("terraform_modules_dir")
 
     @property
@@ -231,8 +234,6 @@ class TerraformCommand(BaseCommand):
         for auth in self._authenticators:
             env.update(auth.env())
 
-        # env["TF_PLUGIN_CACHE_DIR"] = f"{self._temp_dir}/terraform-plugins"
-
         working_dir = f"{self._temp_dir}/definitions/{definition.tag}"
         command_params = params.get(command)
         if not command_params:
@@ -276,13 +277,27 @@ class TerraformCommand(BaseCommand):
             f"{self._terraform_bin} {command} {command_params}",
             cwd=working_dir,
             env=env,
+            stream_output=self._stream_output,
         )
-        if debug:
-            click.secho(f"exit code: {exit_code}", fg="blue")
+        click.secho(f"exit code: {exit_code}", fg="blue")
+
+        if debug and not self._stream_output:
             for line in stdout.decode().splitlines():
                 click.secho(f"stdout: {line}", fg="blue")
             for line in stderr.decode().splitlines():
                 click.secho(f"stderr: {line}", fg="red")
+
+        # If a plan file was saved, write the plan output
+        if plan_file is not None:
+            plan_log = f"{os.path.splitext(plan_file)[0]}.log"
+
+            with open(plan_log, 'w') as pl:
+                pl.write("STDOUT:\n")
+                for line in stdout.decode().splitlines():
+                    pl.write(f"{line}\n")
+                pl.write("\nSTDERR:\n")
+                for line in stderr.decode().splitlines():
+                    pl.write(f"{line}\n")
 
         # special handling of the exit codes for "plan" operations
         if command == "plan":


### PR DESCRIPTION
- update pipe_exec to include the ability to stream output
- update all tests for pipe_exec
- save plan output to logfile when saving a .tfplan file
- add pytest-timeout to dev deps to prevent tests not finishing if errors are introduced in pipe_exec
- add --stream-output option to change how terraform output is handled
- add template_vars option to `definitions`
- cleanup jinja templating error handling