### PR TITLE
add tests for the click cli setup

### DIFF
--- a/tests/commands/test_root.py
+++ b/tests/commands/test_root.py
@@ -14,8 +14,8 @@
 
 import copy
 import os
-from unittest import mock
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 import pytest
 from deepdiff import DeepDiff
@@ -60,7 +60,9 @@ class TestMain:
         # should not be deleted, but contents inside of it should
         tmpdir = TemporaryDirectory()
         assert os.path.exists(tmpdir.name) is True
-        rc = tfworker.commands.root.RootCommand(args={"clean": True, "working_dir": tmpdir.name})
+        rc = tfworker.commands.root.RootCommand(
+            args={"clean": True, "working_dir": tmpdir.name}
+        )
         assert rc.clean is True
         assert str(rc.temp_dir) == tmpdir.name
         with open(file=os.path.join(tmpdir.name, "test"), mode="w") as f:
@@ -99,9 +101,16 @@ class TestMain:
         assert "can not read" in out
 
         # a j2 template with invalid substitutions should raise an error
-        invalidrc = tfworker.commands.root.RootCommand({"config_file": os.path.join(
-                os.path.dirname(__file__), "..", "fixtures", "test_config_invalid_j2.yaml"
-            )})
+        invalidrc = tfworker.commands.root.RootCommand(
+            {
+                "config_file": os.path.join(
+                    os.path.dirname(__file__),
+                    "..",
+                    "fixtures",
+                    "test_config_invalid_j2.yaml",
+                )
+            }
+        )
         with pytest.raises(SystemExit) as e:
             invalidrc.load_config()
         assert e.value.code == 1
@@ -145,7 +154,7 @@ class TestMain:
 
         assert str(rc) == "{'foo': 'bar', 'this': ['that', 'thing'], 'one': 2}"
 
-        for k,v in rc.items():
+        for k, v in rc.items():
             assert k in ["foo", "this", "one"]
             assert v in ["bar", ["that", "thing"], 2]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -428,3 +428,8 @@ def definition_odict():
         )
     }
     return collections.OrderedDict(one_def)
+
+
+@pytest.fixture
+def test_config_file():
+    return os.path.join(os.path.dirname(__file__), "fixtures", "test_config.yaml")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,210 @@
+# Copyright 2023 Richard Maynard (richard.maynard@gmail.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+from unittest import mock
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+import tfworker.cli
+from tfworker.commands import CleanCommand
+
+
+class TestCLI:
+    def test_validate_deployment_valid(self):
+        """ensure valid names are returned"""
+        assert tfworker.cli.validate_deployment(None, None, "test") == "test"
+
+    def test_validate_deployment_invalid_spaces(self, capfd):
+        """ensure deploys with spaces failed"""
+        with pytest.raises(SystemExit) as e:
+            tfworker.cli.validate_deployment(None, None, "test test")
+        out, err = capfd.readouterr()
+        assert e.type == SystemExit
+        assert e.value.code == 1
+        assert "not contain spaces" in out
+
+    def test_validate_deployment_invalid_length(self, capfd):
+        """ensure deploy over 16 chars fail"""
+        with pytest.raises(SystemExit) as e:
+            tfworker.cli.validate_deployment(None, None, "testtesttesttesttest")
+        out, err = capfd.readouterr()
+        assert e.type == SystemExit
+        assert e.value.code == 1
+        assert "16 characters" in out
+
+    def test_validate_gcp_creds_path(self):
+        """ensure valid creds paths are returned"""
+        with tempfile.NamedTemporaryFile(mode="w+") as tmpf:
+            assert (
+                tfworker.cli.validate_gcp_creds_path(None, None, tmpf.name) == tmpf.name
+            )
+
+    def test_validate_gcp_creds_path_invalid(self, capfd):
+        """ensure invalid creds paths fail"""
+        with pytest.raises(SystemExit) as e:
+            tfworker.cli.validate_gcp_creds_path(None, None, "test")
+        out, err = capfd.readouterr()
+        assert e.type == SystemExit
+        assert e.value.code == 1
+        assert "not resolve GCP credentials" in out
+
+    def test_validate_host(self):
+        """only linux and darwin are supported, and require 64 bit platforms"""
+        with patch("tfworker.cli.get_platform", return_value=("linux", "amd64")):
+            assert tfworker.cli.validate_host() is True
+        with patch("tfworker.cli.get_platform", return_value=("darwin", "amd64")):
+            assert tfworker.cli.validate_host() is True
+        with patch("tfworker.cli.get_platform", return_value=("darwin", "arm64")):
+            assert tfworker.cli.validate_host() is True
+
+    def test_validate_host_invalid_machine(self, capfd):
+        """ensure invalid machine types fail"""
+        with patch("tfworker.cli.get_platform", return_value=("darwin", "i386")):
+            with pytest.raises(SystemExit) as e:
+                tfworker.cli.validate_host()
+            out, err = capfd.readouterr()
+            assert e.type == SystemExit
+            assert e.value.code == 1
+            assert "not supported" in out
+
+    def test_validate_host_invalid_os(self, capfd):
+        """ensure invalid os types fail"""
+        with patch("tfworker.cli.get_platform", return_value=("windows", "amd64")):
+            with pytest.raises(SystemExit) as e:
+                tfworker.cli.validate_host()
+            out, err = capfd.readouterr()
+            assert e.type == SystemExit
+            assert e.value.code == 1
+            assert "not supported" in out
+
+    def test_validate_working_dir(self):
+        """ensure valid working dirs are returned"""
+        assert tfworker.cli.validate_working_dir(None) is None
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            assert tfworker.cli.validate_working_dir(tmpd) is None
+
+    def test_validate_working_dir_is_file(self, capfd):
+        """ensure files fail"""
+        with tempfile.NamedTemporaryFile(mode="w+") as tmpf:
+            with pytest.raises(SystemExit) as e:
+                tfworker.cli.validate_working_dir(tmpf.name)
+            out, err = capfd.readouterr()
+            assert e.type == SystemExit
+            assert e.value.code == 1
+            assert "not a directory" in out
+
+    def test_validate_working_dir_does_not_exist(self, capfd):
+        """ensure non existent dirs fail"""
+        with pytest.raises(SystemExit) as e:
+            tfworker.cli.validate_working_dir("test")
+        out, err = capfd.readouterr()
+        assert e.type == SystemExit
+        assert e.value.code == 1
+        assert "does not exist" in out
+
+    def test_validate_working_dir_not_empty(self, capfd):
+        """ensure non empty dirs fail"""
+        with tempfile.TemporaryDirectory() as tmpd:
+            with open(os.path.join(tmpd, "test"), "w+") as tmpf:
+                with pytest.raises(SystemExit) as e:
+                    tfworker.cli.validate_working_dir(tmpd)
+                out, err = capfd.readouterr()
+                assert e.type == SystemExit
+                assert e.value.code == 1
+                assert "must be empty" in out
+
+    def test_cli_no_params(self):
+        """ensure cli returns usage with no params"""
+        from tfworker.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli)
+        assert result.exit_code == 0
+        assert "Usage: cli [OPTIONS] COMMAND [ARGS]..." in result.output
+
+    def test_cli_missing_command(self):
+        """ensure cli returns usage with no command"""
+        from tfworker.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--config-file", "test"])
+        assert result.exit_code == 2
+        assert "Missing command" in result.output
+
+    def test_cli_invalid_config(self):
+        """ensure the CLI fails with an invalid config file"""
+        # @TODO(ephur): this test demonstrates an issue with how rendering exits
+        #      when it encounters errors, this masks the true error of config
+        #      file not being found.  This should be fixed in a future PR.
+        from tfworker.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--config-file", "test", "terraform", "foo"])
+        assert result.exit_code == 1
+        # the expected result is: configuration file {config_file} not found" the
+        # exception is being handled in the wrong place
+        assert "not read" in result.output
+
+    @patch("tfworker.cli.CleanCommand", autospec=True)
+    def test_cli_clean_command(self, mock_request, test_config_file):
+        """ensure the CLI clean command executes"""
+        from tfworker.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--config-file", test_config_file, "clean", "foo"])
+        mock_request.assert_called_once()
+        assert mock_request.method_calls[0][0] == "().exec"
+
+    @patch("tfworker.cli.VersionCommand", autospec=True)
+    def test_cli_version_command(self, mock_request, test_config_file):
+        """ensure the CLI version command executes"""
+        from tfworker.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["version"])
+        mock_request.assert_called_once()
+        assert mock_request.method_calls[0][0] == "().exec"
+
+    @patch("tfworker.cli.TerraformCommand", autospec=True)
+    def test_cli_terraform_command(self, mock_request, test_config_file):
+        """ensure the CLI terraform command executes
+        @TODO(ephur): This test demonstrates why the CLI skel should only
+        call the exec method of the command, and not the other methods.
+        """
+        from tfworker.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--config-file", test_config_file, "terraform", "foo"]
+        )
+        assert result.exit_code == 0
+        # the three steps the cli should execute
+        assert mock_request.method_calls[0][0] == "().plugins.download"
+        assert mock_request.method_calls[1][0] == "().prep_modules"
+        assert mock_request.method_calls[2][0] == "().exec"
+
+    @patch("tfworker.cli.EnvCommand", autospec=True)
+    def test_cli_env_command(self, mock_request, test_config_file):
+        """ensure the CLI env command executes"""
+        from tfworker.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--config-file", test_config_file, "env"])
+        mock_request.assert_called_once()
+        assert mock_request.method_calls[0][0] == "().exec"

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -32,7 +32,10 @@ def validate_deployment(ctx, deployment, name):
     """Validate the deployment is no more than 16 characters."""
     if len(name) > 16:
         click.secho("deployment must be less than 16 characters", fg="red")
-        raise SystemExit(2)
+        raise SystemExit(1)
+    if " " in name:
+        click.secho("deployment must not contain spaces", fg="red")
+        raise SystemExit(1)
     return name
 
 
@@ -43,7 +46,7 @@ def validate_gcp_creds_path(ctx, path, value):
         if os.path.isfile(value):
             return value
         click.secho(f"Could not resolve GCP credentials path: {value}", fg="red")
-        raise SystemExit(3)
+        raise SystemExit(1)
 
 
 def validate_host():
@@ -55,22 +58,17 @@ def validate_host():
 
     if opsys not in supported_opsys:
         click.secho(
-            f"this application is currently not known to support {opsys}",
+            f"running on {opsys} is not supported",
             fg="red",
         )
-        raise SystemExit(2)
+        raise SystemExit(1)
 
     if machine not in supported_machine:
         click.secho(
-            f"this application is currently not known to support running on {machine} machines",
+            f"running on {machine} machines is not supported",
             fg="red",
         )
-
-    if struct.calcsize("P") * 8 != 64:
-        click.secho(
-            "this application can only be run on 64 bit hosts, in 64 bit mode", fg="red"
-        )
-        raise SystemExit(2)
+        raise SystemExit(1)
 
     return True
 
@@ -324,7 +322,7 @@ def terraform(rootc, *args, **kwargs):
     tfc = TerraformCommand(rootc, *args, **kwargs)
 
     click.secho(f"building deployment {kwargs.get('deployment')}", fg="green")
-    click.secho(f"using temporary Directory: {tfc.temp_dir}", fg="yellow")
+    click.secho(f"working in directory: {tfc.temp_dir}", fg="yellow")
 
     # common setup required for all definitions
     click.secho("preparing provider plugins", fg="green")


### PR DESCRIPTION
There were previously no tests for the click cli framework. This PR adds complete coverage for the cli validation methods, and ensures the command objects are executed as expected. The tests uncover some lingering issues, check the @TODO's

Also updated exit codes and error messages emitted from the base CLI to be more consistent.