### PR TITLE
Increase the limit of deploymment names to 32 characters.

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,11 +41,11 @@ class TestCLI:
     def test_validate_deployment_invalid_length(self, capfd):
         """ensure deploy over 16 chars fail"""
         with pytest.raises(SystemExit) as e:
-            tfworker.cli.validate_deployment(None, None, "testtesttesttesttest")
+            tfworker.cli.validate_deployment(None, None, "testtesttesttesttesttesttesttesttesttest")
         out, err = capfd.readouterr()
         assert e.type == SystemExit
         assert e.value.code == 1
-        assert "16 characters" in out
+        assert "32 characters" in out
 
     def test_validate_gcp_creds_path(self):
         """ensure valid creds paths are returned"""

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -29,9 +29,9 @@ from tfworker.commands.version import VersionCommand
 
 
 def validate_deployment(ctx, deployment, name):
-    """Validate the deployment is no more than 16 characters."""
-    if len(name) > 16:
-        click.secho("deployment must be less than 16 characters", fg="red")
+    """Validate the deployment is no more than 32 characters."""
+    if len(name) > 32:
+        click.secho("deployment must be less than 32 characters", fg="red")
         raise SystemExit(1)
     if " " in name:
         click.secho("deployment must not contain spaces", fg="red")


### PR DESCRIPTION
The limit on deployment name length was largely an arbitrary decision and was used since it was expected to use the {{ deployment }} variable it creates for inclusion in naming terraform resources. This increases the arbitrary limit but does not completely remove limits because unbounded deployment lengths will cause problems when setting up remote backends.