### PR TITLE
update deployment limit and remove print statements

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,11 +41,11 @@ class TestCLI:
     def test_validate_deployment_invalid_length(self, capfd):
         """ensure deploy over 16 chars fail"""
         with pytest.raises(SystemExit) as e:
-            tfworker.cli.validate_deployment(None, None, "testtesttesttesttest")
+            tfworker.cli.validate_deployment(None, None, "testtesttesttesttesttesttesttesttesttest")
         out, err = capfd.readouterr()
         assert e.type == SystemExit
         assert e.value.code == 1
-        assert "16 characters" in out
+        assert "32 characters" in out
 
     def test_validate_gcp_creds_path(self):
         """ensure valid creds paths are returned"""

--- a/tfworker/authenticators/__init__.py
+++ b/tfworker/authenticators/__init__.py
@@ -23,7 +23,6 @@ ALL = [AWSAuthenticator, GoogleAuthenticator]
 
 class AuthenticatorsCollection(collections.abc.Mapping):
     def __init__(self, state_args, **kwargs):
-        print(state_args)
         self._authenticators = dict(
             [(auth.tag, auth(state_args, **kwargs)) for auth in ALL]
         )

--- a/tfworker/authenticators/aws.py
+++ b/tfworker/authenticators/aws.py
@@ -30,7 +30,6 @@ class AWSAuthenticator(BaseAuthenticator):
 
     def __init__(self, state_args, **kwargs):
         super(AWSAuthenticator, self).__init__(state_args, **kwargs)
-        print(state_args)
         self.bucket = self._resolve_arg("backend_bucket")
         if not self.bucket:
             raise MissingArgumentException("backend_bucket is a required argument")

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -29,9 +29,9 @@ from tfworker.commands.version import VersionCommand
 
 
 def validate_deployment(ctx, deployment, name):
-    """Validate the deployment is no more than 16 characters."""
-    if len(name) > 16:
-        click.secho("deployment must be less than 16 characters", fg="red")
+    """Validate the deployment is no more than 32 characters."""
+    if len(name) > 32:
+        click.secho("deployment must be less than 32 characters", fg="red")
         raise SystemExit(1)
     if " " in name:
         click.secho("deployment must not contain spaces", fg="red")


### PR DESCRIPTION
Some debug print messages slipped through in a recent PR, remove those.
The decision to have a 16 character limit on deployment names was arbitrary, unbounded deployment names would need more checks to handle backends, but 32 is a safe limit within all the backend resource limitations from the supported cloud providers.