### PR TITLE
INF-5080: handle filenot found error with specified subpath

### DIFF
--- a/tests/util/test_copier.py
+++ b/tests/util/test_copier.py
@@ -317,6 +317,15 @@ class TestFileSystemCopier:
         c.copy()
         assert os.path.isfile(f"{str(tmp_path)}/test.tf")
 
+        c = FileSystemCopier(
+            source="/tests/fixtures/definitions/test_a",
+            root_path=f"{request.config.rootdir}",
+            destination=f"{str(tmp_path)}",
+        )
+
+        with pytest.raises(FileNotFoundError):
+            c.copy(sub_path="invalid_path")
+
     def test_local_path(self):
         """tests the local path property"""
 

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -125,6 +125,15 @@ class Definition:
 
         try:
             c.copy(destination=self._target, **remote_options)
+        except FileNotFoundError as e:
+            if remote_options.get("sub_path", False):
+                click.secho(
+                    f"could not find sub_path {remote_options['sub_path']} for definition {self.tag}",
+                    fg="red",
+                )
+                raise SystemExit(1)
+            else:
+                raise e
         except FileExistsError as e:
             raise ReservedFileError(e)
 

--- a/tfworker/util/copier.py
+++ b/tfworker/util/copier.py
@@ -232,6 +232,8 @@ class FileSystemCopier(Copier):
         dest = self.get_destination(**kwargs)
         self.check_conflicts(self.local_path)
         source_path = f"{self.local_path}/{kwargs.get('sub_path', '')}".rstrip("/")
+        if not os.path.exists(source_path):
+            raise FileNotFoundError(f"{kwargs.get('sub_path')} does not exist")
         shutil.copytree(source_path, dest, dirs_exist_ok=True)
 
     @property


### PR DESCRIPTION
An invalid configuration could trigger an unhandled exception. This PR catches the exception and provides useful troubleshooting information. Includes tests.