### PR TITLE
Move the root options to a Pydantic Model

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
-known_third_party = atlassian,boto3,botocore,click,deepdiff,google,hcl2,jinja2,mergedeep,moto,pydantic,pytest,yaml
+known_third_party = atlassian,boto3,botocore,click,deepdiff,google,hcl2,jinja2,lark,mergedeep,moto,pydantic,pytest,yaml
 profile = black

--- a/tests/backends/test_gcs.py
+++ b/tests/backends/test_gcs.py
@@ -171,25 +171,25 @@ class TestClean:
             assert gbasec.backend._parse_gcs_items(inval) == outval
 
 
-def test_google_hcl(gbasec):
+def test_google_hcl(gbasec, gcp_creds_file):
     render = gbasec.backend.hcl("test")
-    expected_render = """  backend "gcs" {
+    expected_render = f"""  backend "gcs" {{
     bucket = "test_gcp_bucket"
     prefix = "terraform/test-0002/test"
-    credentials = "/home/test/test-creds.json"
-  }"""
+    credentials = "{gcp_creds_file}"
+  }}"""
     assert render == expected_render
 
 
-def test_google_data_hcl(gbasec):
-    expected_render = """data "terraform_remote_state" "test" {
+def test_google_data_hcl(gbasec, gcp_creds_file):
+    expected_render = f"""data "terraform_remote_state" "test" {{
   backend = "gcs"
-  config = {
+  config = {{
     bucket = "test_gcp_bucket"
     prefix = "terraform/test-0002/test"
-    credentials = "/home/test/test-creds.json"
-  }
-}"""
+    credentials = "{gcp_creds_file}"
+  }}
+}}"""
     render = []
     render.append(gbasec.backend.data_hcl(["test", "test"]))
     render.append(gbasec.backend.data_hcl(["test"]))

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 
-def test_google_hcl(basec):
+def test_google_hcl(basec, gcp_creds_file):
     render = basec.providers["google"].hcl()
-    expected_render = """provider "google" {
+    expected_render = f"""provider "google" {{
   region = "us-west-2"
-  credentials = file("/home/test/test-creds.json")
-}"""
+  credentials = file("{gcp_creds_file}")
+}}"""
 
     assert render == expected_render

--- a/tests/providers/test_google_beta.py
+++ b/tests/providers/test_google_beta.py
@@ -1,8 +1,8 @@
-def test_google_hcl(basec):
+def test_google_hcl(basec, gcp_creds_file):
     render = basec.providers["google-beta"].hcl()
-    expected_render = """provider "google-beta" {
+    expected_render = f"""provider "google-beta" {{
   region = "us-west-2"
-  credentials = file("/home/test/test-creds.json")
-}"""
+  credentials = file("{gcp_creds_file}")
+}}"""
 
     assert render == expected_render

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -47,22 +45,6 @@ class TestCLI:
         assert e.value.code == 1
         assert "32 characters" in out
 
-    def test_validate_gcp_creds_path(self):
-        """ensure valid creds paths are returned"""
-        with tempfile.NamedTemporaryFile(mode="w+") as tmpf:
-            assert (
-                tfworker.cli.validate_gcp_creds_path(None, None, tmpf.name) == tmpf.name
-            )
-
-    def test_validate_gcp_creds_path_invalid(self, capfd):
-        """ensure invalid creds paths fail"""
-        with pytest.raises(SystemExit) as e:
-            tfworker.cli.validate_gcp_creds_path(None, None, "test")
-        out, err = capfd.readouterr()
-        assert e.type == SystemExit
-        assert e.value.code == 1
-        assert "not resolve GCP credentials" in out
-
     def test_validate_host(self):
         """only linux and darwin are supported, and require 64 bit platforms"""
         with patch("tfworker.cli.get_platform", return_value=("linux", "amd64")):
@@ -91,43 +73,6 @@ class TestCLI:
             assert e.type == SystemExit
             assert e.value.code == 1
             assert "not supported" in out
-
-    def test_validate_working_dir(self):
-        """ensure valid working dirs are returned"""
-        assert tfworker.cli.validate_working_dir(None) is None
-
-        with tempfile.TemporaryDirectory() as tmpd:
-            assert tfworker.cli.validate_working_dir(tmpd) is None
-
-    def test_validate_working_dir_is_file(self, capfd):
-        """ensure files fail"""
-        with tempfile.NamedTemporaryFile(mode="w+") as tmpf:
-            with pytest.raises(SystemExit) as e:
-                tfworker.cli.validate_working_dir(tmpf.name)
-            out, err = capfd.readouterr()
-            assert e.type == SystemExit
-            assert e.value.code == 1
-            assert "not a directory" in out
-
-    def test_validate_working_dir_does_not_exist(self, capfd):
-        """ensure non existent dirs fail"""
-        with pytest.raises(SystemExit) as e:
-            tfworker.cli.validate_working_dir("test")
-        out, err = capfd.readouterr()
-        assert e.type == SystemExit
-        assert e.value.code == 1
-        assert "does not exist" in out
-
-    def test_validate_working_dir_not_empty(self, capfd):
-        """ensure non empty dirs fail"""
-        with tempfile.TemporaryDirectory() as tmpd:
-            with open(os.path.join(tmpd, "test"), "w+"):
-                with pytest.raises(SystemExit) as e:
-                    tfworker.cli.validate_working_dir(tmpd)
-                out, err = capfd.readouterr()
-                assert e.type == SystemExit
-                assert e.value.code == 1
-                assert "must be empty" in out
 
     def test_cli_no_params(self):
         """ensure cli returns usage with no params"""

--- a/tests/types/test_cli_options.py
+++ b/tests/types/test_cli_options.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+import pytest
+
+from tfworker.types import CLIOptionsRoot
+
+
+def test_working_dir_validator_with_valid_directory():
+    with TemporaryDirectory() as temp_dir:
+        options = CLIOptionsRoot(working_dir=temp_dir)
+        assert options.working_dir == temp_dir
+
+
+def test_working_dir_validator_with_non_existent_directory():
+    with pytest.raises(ValueError, match=r"Working path .* does not exist!"):
+        CLIOptionsRoot(working_dir="/non/existent/path")
+
+
+def test_working_dir_validator_with_file_instead_of_directory():
+    with TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "file.txt"
+        file_path.touch()
+        with pytest.raises(ValueError, match=r"Working path .* is not a directory!"):
+            CLIOptionsRoot(working_dir=str(file_path))
+
+
+def test_working_dir_validator_with_non_empty_directory():
+    with TemporaryDirectory() as temp_dir:
+        (Path(temp_dir) / "file.txt").touch()
+        with pytest.raises(ValueError, match=r"Working path .* must be empty!"):
+            CLIOptionsRoot(working_dir=temp_dir)
+
+
+def test_clean_validator_with_working_dir_set_and_clean_not_set():
+    with TemporaryDirectory() as temp_dir:
+        options = CLIOptionsRoot(working_dir=temp_dir)
+        assert options.clean is False
+
+
+def test_clean_validator_with_working_dir_not_set_and_clean_not_set():
+    options = CLIOptionsRoot()
+    assert options.clean is True
+
+
+def test_clean_validator_with_working_dir_set_and_clean_set_to_true():
+    with TemporaryDirectory() as temp_dir:
+        options = CLIOptionsRoot(working_dir=temp_dir, clean=True)
+        assert options.clean is True
+
+
+def test_clean_validator_with_working_dir_not_set_and_clean_set_to_false():
+    options = CLIOptionsRoot(clean=False)
+    assert options.clean is False
+
+
+def test_validate_gcp_creds_path():
+    # Test with a non-existing file
+    with pytest.raises(ValueError, match=r"Path .* is not a file!"):
+        CLIOptionsRoot(gcp_creds_path="non_existing_file.json")
+
+    # Test with a directory
+    with pytest.raises(ValueError, match=r"Path .* is not a file!"):
+        CLIOptionsRoot(gcp_creds_path=".")
+
+    # Test with a valid file
+    # Create a temporary file for the test
+    with NamedTemporaryFile() as temp_file:
+        # The validator should not raise any exception for a valid file
+        CLIOptionsRoot(gcp_creds_path=temp_file.name)

--- a/tests/util/test_util_cli.py
+++ b/tests/util/test_util_cli.py
@@ -1,0 +1,79 @@
+from typing import List, Optional
+
+import click
+import pytest
+from pydantic import BaseModel, Field
+
+from tfworker.util.cli import pydantic_to_click
+
+
+class ATestModel(BaseModel):
+    str_field: str
+    optional_str_field: Optional[str] = None
+    int_field: int
+    optional_int_field: Optional[int] = None
+    float_field: float
+    optional_float_field: Optional[float] = None
+    bool_field: bool
+    optional_bool_field: Optional[bool] = None
+    list_str_field: List[str] = Field(required=True)
+    optional_list_str_field: Optional[List[str]] = []
+
+
+@click.command()
+@pydantic_to_click(ATestModel)
+def a_command():
+    pass
+
+
+def test_pydantic_to_click():
+    command = a_command
+
+    # Check that the command is a Click command
+    assert isinstance(command, click.Command)
+
+    # Check that the command has the correct options
+    options = {option.name: option for option in command.params}
+    assert set(options.keys()) == set(ATestModel.__annotations__.keys())
+
+    # Check the types of the options
+    assert isinstance(options["str_field"].type, click.types.StringParamType)
+    assert isinstance(options["optional_str_field"].type, click.types.StringParamType)
+    assert isinstance(options["int_field"].type, click.types.IntParamType)
+    assert isinstance(options["optional_int_field"].type, click.types.IntParamType)
+    assert isinstance(options["float_field"].type, click.types.FloatParamType)
+    assert isinstance(options["optional_float_field"].type, click.types.FloatParamType)
+    assert isinstance(options["bool_field"].type, click.types.BoolParamType)
+    assert isinstance(options["optional_bool_field"].type, click.types.BoolParamType)
+    assert isinstance(options["list_str_field"].type, click.types.StringParamType)
+    assert isinstance(
+        options["optional_list_str_field"].type, click.types.StringParamType
+    )
+
+    # Check the 'multiple' attribute of the options
+    assert options["list_str_field"].multiple is True
+    assert options["optional_list_str_field"].multiple is True
+
+    # Check the 'required' attribute of the options
+    assert options["str_field"].required is True
+    assert options["optional_str_field"].required is False
+    assert options["int_field"].required is True
+    assert options["optional_int_field"].required is False
+    assert options["float_field"].required is True
+    assert options["optional_float_field"].required is False
+    assert options["bool_field"].required is True
+    assert options["optional_bool_field"].required is False
+    assert options["list_str_field"].required is True
+    assert options["optional_list_str_field"].required is False
+
+
+class UnsupportedModel(BaseModel):
+    unsupported_field: dict
+
+
+def test_unsupported_type():
+    with pytest.raises(ValueError, match=r"Unsupported type <class 'dict'>"):
+
+        @pydantic_to_click(UnsupportedModel)
+        def a_command():
+            pass

--- a/tests/util/test_util_terraform.py
+++ b/tests/util/test_util_terraform.py
@@ -177,7 +177,7 @@ def test_get_tf_version(
 def mock_mirror_setup():
     mock_mirror_settings = {
         "providers": MagicMock(),
-        'terraform_bin': "/path/to/terraform",
+        "terraform_bin": "/path/to/terraform",
         "working_dir": "/working/dir",
         "cache_dir": "/cache/dir",
         "temp_dir": "/temp/dir",
@@ -208,7 +208,7 @@ def test_mirror_providers(mock_mirror_setup):
 
     result = mirror_providers(
         providers=mock_mirror_settings["providers"],
-        terraform_bin=mock_mirror_settings['terraform_bin'],
+        terraform_bin=mock_mirror_settings["terraform_bin"],
         working_dir=mock_mirror_settings["working_dir"],
         cache_dir=mock_mirror_settings["cache_dir"],
     )
@@ -243,7 +243,7 @@ def test_mirror_providers_tf_error(mock_mirror_setup):
     with pytest.raises(SystemExit):
         mirror_providers(
             providers=mock_mirror_settings["providers"],
-            terraform_bin=mock_mirror_settings['terraform_bin'],
+            terraform_bin=mock_mirror_settings["terraform_bin"],
             working_dir=mock_mirror_settings["working_dir"],
             cache_dir=mock_mirror_settings["cache_dir"],
         )
@@ -273,7 +273,7 @@ def test_mirror_providers_all_in_cache(mock_mirror_setup):
 
     mirror_providers(
         providers=mock_mirror_settings["providers"],
-        terraform_bin=mock_mirror_settings['terraform_bin'],
+        terraform_bin=mock_mirror_settings["terraform_bin"],
         working_dir=mock_mirror_settings["working_dir"],
         cache_dir=mock_mirror_settings["cache_dir"],
     )

--- a/tfworker/commands/base.py
+++ b/tfworker/commands/base.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import click
 import pathlib
+
+import click
 
 from tfworker.authenticators import AuthenticatorsCollection
 from tfworker.backends import BackendError, select_backend

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -219,7 +219,9 @@ class Definition:
         )
 
         if result is not None:
-            with open(f"{self._target}/{TF_PROVIDER_DEFAULT_LOCKFILE}", "w") as lockfile:
+            with open(
+                f"{self._target}/{TF_PROVIDER_DEFAULT_LOCKFILE}", "w"
+            ) as lockfile:
                 lockfile.write(result)
 
     @staticmethod

--- a/tfworker/providers/providers_collection.py
+++ b/tfworker/providers/providers_collection.py
@@ -14,7 +14,6 @@
 
 import collections
 import copy
-import click
 from typing import List
 
 from tfworker.providers.generic import GenericProvider

--- a/tfworker/types/__init__.py
+++ b/tfworker/types/__init__.py
@@ -1,3 +1,4 @@
+from tfworker.types.cli_options import CLIOptionsRoot  # noqa: F401
 from tfworker.types.json import JSONType  # noqa: F401
 from tfworker.types.provider import ProviderConfig, Requirements  # noqa: F401
 from tfworker.types.terraform import (  # noqa: F401

--- a/tfworker/types/cli_options.py
+++ b/tfworker/types/cli_options.py
@@ -1,0 +1,163 @@
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator, root_validator
+
+from tfworker import constants as const
+
+
+class CLIOptionsRoot(BaseModel):
+    aws_access_key_id: Optional[str] = Field(
+        None, env="AWS_ACCESS_KEY_ID", description="AWS Access key"
+    )
+    aws_secret_access_key: Optional[str] = Field(
+        None, env="AWS_SECRET_ACCESS_KEY", description="AWS access key secret"
+    )
+    aws_session_token: Optional[str] = Field(
+        None, env="AWS_SESSION_TOKEN", description="AWS access key token"
+    )
+    aws_role_arn: Optional[str] = Field(
+        None,
+        env="AWS_ROLE_ARN",
+        description="If provided, credentials will be used to assume this role (complete ARN)",
+    )
+    aws_external_id: Optional[str] = Field(
+        None,
+        env="AWS_EXTERNAL_ID",
+        description="If provided, will be used to assume the role specified by --aws-role-arn",
+    )
+    aws_region: str = Field(
+        const.DEFAULT_AWS_REGION,
+        env="AWS_DEFAULT_REGION",
+        description="AWS Region to build in",
+    )
+    aws_profile: Optional[str] = Field(
+        None, env="AWS_PROFILE", description="The AWS/Boto3 profile to use"
+    )
+    gcp_region: str = Field(
+        const.DEFAULT_GCP_REGION, env="GCP_REGION", description="Region to build in"
+    )
+    gcp_creds_path: Optional[str] = Field(
+        None,
+        env="GCP_CREDS_PATH",
+        description="Relative path to the credentials JSON file for the service account to be used.",
+    )
+    gcp_project: Optional[str] = Field(
+        None,
+        env="GCP_PROJECT",
+        description="GCP project name to which work will be applied",
+    )
+    config_file: str = Field(
+        const.DEFAULT_CONFIG,
+        env="WORKER_CONFIG_FILE",
+        description="Path to the configuration file",
+        required=True,
+    )
+    repository_path: str = Field(
+        const.DEFAULT_REPOSITORY_PATH,
+        env="WORKER_REPOSITORY_PATH",
+        description="The path to the terraform module repository",
+        required=True,
+    )
+    backend: Optional[str] = Field(
+        None,
+        env="WORKER_BACKEND",
+        description="State/locking provider. One of: s3, gcs",
+    )
+    backend_bucket: Optional[str] = Field(
+        None,
+        env="WORKER_BACKEND_BUCKET",
+        description="Bucket (must exist) where all terraform states are stored",
+    )
+    backend_prefix: str = Field(
+        const.DEFAULT_BACKEND_PREFIX,
+        env="WORKER_BACKEND_PREFIX",
+        description="Prefix to use in backend storage bucket for all terraform states",
+    )
+    backend_region: str = Field(
+        const.DEFAULT_AWS_REGION,
+        description="Region where terraform root/lock bucket exists",
+    )
+    backend_use_all_remotes: bool = Field(
+        True,
+        env="WORKER_BACKEND_USE_ALL_REMOTES",
+        description="Generate remote data sources based on all definition paths present in the backend",
+    )
+    create_backend_bucket: bool = Field(
+        True, description="Create the backend bucket if it does not exist"
+    )
+    config_var: Optional[List[str]] = Field(
+        [],
+        description='key=value to be supplied as jinja variables in config_file under "var" dictionary, can be specified multiple times',
+    )
+    working_dir: Optional[str] = Field(
+        None,
+        env="WORKER_WORKING_DIR",
+        description="Specify the path to use instead of a temporary directory, must exist, be empty, and be writeable, --clean applies to this directory as well",
+    )
+    clean: Optional[bool] = Field(
+        None,
+        env="WORKER_CLEAN",
+        description="Clean up the temporary directory created by the worker after execution",
+    )
+    backend_plans: bool = Field(
+        False, env="WORKER_BACKEND_PLANS", description="Store plans in the backend"
+    )
+
+    @root_validator(pre=True)
+    def set_default_clean(cls, values):
+        if values.get("working_dir") is not None:
+            if "clean" not in values or values["clean"] is None:
+                values["clean"] = False
+        else:
+            if "clean" not in values or values["clean"] is None:
+                values["clean"] = True
+        return values
+
+    @field_validator("working_dir")
+    @classmethod
+    def validate_working_dir(cls, fpath: Union[str, None]) -> Union[str, None]:
+        """Validate the working directory path.
+
+        Args:
+            fpath: Path to the working directory.
+
+        Returns:
+            Path to the working directory.
+
+        Raises:
+            ValueError: If the path does not exist, is not a directory, or is not empty.
+        """
+        if fpath is None:
+            return
+        with Path(fpath) as wpath:
+            if not wpath.exists():
+                raise ValueError(f"Working path {fpath} does not exist!")
+            if not wpath.is_dir():
+                raise ValueError(f"Working path {fpath} is not a directory!")
+            if any(wpath.iterdir()):
+                raise ValueError(f"Working path {fpath} must be empty!")
+        return fpath
+
+    @field_validator("gcp_creds_path")
+    @classmethod
+    def validate_gcp_creds_path(cls, fpath: Union[str, None]) -> Union[str, None]:
+        """Validate the GCP credentials path.
+
+        Args:
+            fpath: Path to the GCP credentials file.
+
+        Returns:
+            Fully resolved path to the GCP credentials file.
+
+        Raises:
+            ValueError: If the path does not exist or is not a file.
+        """
+        if fpath is None:
+            return
+        if not os.path.isabs(fpath):
+            fpath = os.path.abspath(fpath)
+        if os.path.isfile(fpath):
+            return fpath
+        raise ValueError(f"Path {fpath} is not a file!")

--- a/tfworker/util/cli.py
+++ b/tfworker/util/cli.py
@@ -1,0 +1,59 @@
+import typing as t
+
+import click
+from pydantic import BaseModel
+from pydantic.fields import PydanticUndefined
+
+
+def pydantic_to_click(pydantic_model: t.Type[BaseModel]) -> click.Command:
+    """Convert a Pydantic model to a Click command.
+
+    Args:
+        pydantic_model: Pydantic model to convert.
+
+    Returns:
+        Click command.
+    """
+
+    def decorator(func):
+        model_types = t.get_type_hints(pydantic_model)
+        for fname, fdata in pydantic_model.model_fields.items():
+            description = fdata.description or ""
+            default = fdata.default
+            multiple = False
+
+            if model_types[fname] in [str, t.Optional[str]]:
+                option_type = click.STRING
+            elif model_types[fname] in [int, t.Optional[int]]:
+                option_type = click.INT
+            elif model_types[fname] in [float, t.Optional[float]]:
+                option_type = click.FLOAT
+            elif model_types[fname] in [bool, t.Optional[bool]]:
+                option_type = click.BOOL
+            elif model_types[fname] in [t.List[str], t.Optional[t.List[str]]]:
+                option_type = click.STRING
+                multiple = True
+                if default is PydanticUndefined:
+                    default = []
+            else:
+                raise ValueError(f"Unsupported type {model_types[fname]}")
+
+            c_option_args = [f"--{fname.replace('_', '-')}"]
+            c_option_kwargs = {
+                "help": description,
+                "default": default,
+                "type": option_type,
+                "required": fdata.is_required(),
+                "multiple": multiple,
+            }
+
+            if option_type == click.BOOL:
+                c_option_args = [
+                    f"--{fname.replace('_', '-')}/--no-{fname.replace('_', '-')}"
+                ]
+                del c_option_kwargs["type"]
+
+            func = click.option(*c_option_args, **c_option_kwargs)(func)
+        return func
+
+    return decorator

--- a/tfworker/util/terraform.py
+++ b/tfworker/util/terraform.py
@@ -196,6 +196,8 @@ def get_provider_gid_from_source(source: str) -> ProviderGID:
 
     return ProviderGID(hostname=hostname, namespace=namespace, type=ptype)
 
+
+@lru_cache
 def find_required_providers(
     search_dir: str,
 ) -> Union[None, Dict[str, [Dict[str, str]]]]:

--- a/tfworker/util/terraform_helpers.py
+++ b/tfworker/util/terraform_helpers.py
@@ -1,13 +1,11 @@
 import json
 import os
 import pathlib
-from functools import lru_cache
 from tempfile import TemporaryDirectory
 from typing import Dict, List, Union
 
 import click
 import hcl2
-
 from lark.exceptions import UnexpectedToken
 
 from tfworker.providers.providers_collection import ProvidersCollection
@@ -168,7 +166,6 @@ def _parse_required_providers(content: dict) -> Union[None, Dict[str, Dict[str, 
     return providers
 
 
-@lru_cache
 def _find_required_providers(search_dir: str) -> Dict[str, [Dict[str, str]]]:
     providers = {}
     for root, _, files in os.walk(search_dir, followlinks=True):


### PR DESCRIPTION
The long term is goal is to move all CLI configurations to models. Currently attributes are slapped onto one big inherited object and make it difficult to determine where something is coming from, and there is significant coupling.

Moving the options into a base model allows for all validation and conditional logic to be handled within the model, and then the model can be passed to places where the configuration may be needed. This will lessen the overuse of passing around big sets of kwargs and taking out what is needed, and will ensure that the CLI options are seamlessly available in all the different areas they are needed.

This starts with just the RootCommand, which takes the "global" or top level options.