### PR TITLE
cleanup aws backend

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ def mock_app_state(
     mock_state.loaded_config.worker_options = {}
     mock_state.loaded_config.global_vars = GlobalVars()
     mock_state.working_dir = str(tmpdir)
+    mock_state.terraform_version = (1, 13)
 
     return mock_state
 
@@ -165,6 +166,7 @@ def mock_app_state_backend_west(
     mock_state.loaded_config.definitions = {}
     mock_state.loaded_config.handlers = {}
     mock_state.working_dir = str(tmpdir)
+    mock_state.terraform_version = (1, 13)
     return mock_state
 
 

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -1,5 +1,10 @@
+import os
 import pytest
 from tfworker import cli_options as c
+
+skip_permissions = pytest.mark.skipif(
+    os.geteuid() == 0, reason="permission tests require non-root user"
+)
 
 
 class TestCLIOptionsRoot:
@@ -51,6 +56,7 @@ class TestCLIOptionsRoot:
         with pytest.raises(ValueError):
             c.CLIOptionsRoot(config_file=str(config_file))
 
+    @skip_permissions
     def test_config_file_is_not_readable(self, tmp_path):
         config_file = tmp_path / "config.yaml"
         config_file.touch()
@@ -114,6 +120,7 @@ class TestCLIOptionsRoot:
         with pytest.raises(ValueError):
             c.CLIOptionsRoot(repository_path=None)
 
+    @skip_permissions
     def test_repository_path_not_writable(self, tmp_path):
         repository_path = tmp_path / "dir"
         repository_path.mkdir()
@@ -122,6 +129,7 @@ class TestCLIOptionsRoot:
             c.CLIOptionsRoot(repository_path=str(repository_path))
         repository_path.chmod(0o755)
 
+    @skip_permissions
     def test_repository_path_not_readable(self, tmp_path):
         repository_path = tmp_path / "dir"
         repository_path.mkdir()
@@ -149,6 +157,7 @@ class TestCLIOptionsRoot:
         cli_options = c.CLIOptionsRoot(working_dir=None)
         assert cli_options.working_dir is None
 
+    @skip_permissions
     def test_working_dir_not_writable(self, tmp_path):
         working_dir = tmp_path / "dir"
         working_dir.mkdir()
@@ -157,6 +166,7 @@ class TestCLIOptionsRoot:
             c.CLIOptionsRoot(working_dir=str(working_dir))
         working_dir.chmod(0o755)
 
+    @skip_permissions
     def test_working_dir_not_readable(self, tmp_path):
         working_dir = tmp_path / "dir"
         working_dir.mkdir()
@@ -208,6 +218,7 @@ class TestCLIOptionsTerraform:
         with pytest.raises(ValueError):
             c.CLIOptionsTerraform(terraform_bin=None)
 
+    @skip_permissions
     def test_validate_terraform_bin_not_executable(self, tmp_path):
         terraform_bin = tmp_path / "terraform"
         terraform_bin.touch()
@@ -235,6 +246,7 @@ class TestCLIOptionsTerraform:
         cli_options = c.CLIOptionsTerraform(provider_cache=None)
         assert cli_options.provider_cache is None
 
+    @skip_permissions
     def test_validate_provider_cache_not_writable(self, tmp_path):
         provider_cache = tmp_path / "dir"
         provider_cache.mkdir()
@@ -243,6 +255,7 @@ class TestCLIOptionsTerraform:
             c.CLIOptionsTerraform(provider_cache=str(provider_cache))
         provider_cache.chmod(0o755)
 
+    @skip_permissions
     def test_validate_provider_cache_not_readable(self, tmp_path):
         provider_cache = tmp_path / "dir"
         provider_cache.mkdir()
@@ -270,6 +283,7 @@ class TestCLIOptionsTerraform:
         cli_options = c.CLIOptionsTerraform(plan_file_path=None)
         assert cli_options.plan_file_path is None
 
+    @skip_permissions
     def test_validate_plan_file_path_not_writable(self, tmp_path):
         plan_file_path = tmp_path / "dir"
         plan_file_path.mkdir()
@@ -278,6 +292,7 @@ class TestCLIOptionsTerraform:
             c.CLIOptionsTerraform(plan_file_path=str(plan_file_path))
         plan_file_path.chmod(0o755)
 
+    @skip_permissions
     def test_validate_plan_file_path_not_readable(self, tmp_path):
         plan_file_path = tmp_path / "dir"
         plan_file_path.mkdir()

--- a/tests/util/test_util_hooks.py
+++ b/tests/util/test_util_hooks.py
@@ -285,7 +285,11 @@ class TestHelperFunctions:
             True,
         )
         mock_pipe_exec.assert_called_once_with(
-            "hook_script pre plan", cwd="working_dir/hooks", env={}, stream_output=False
+            "hook_script pre plan",
+            stdin=None,
+            cwd="working_dir/hooks",
+            env={},
+            stream_output=False,
         )
         captured = capsys.readouterr()
         captured_lines = captured.out.splitlines()

--- a/tfworker/app_state.py
+++ b/tfworker/app_state.py
@@ -65,6 +65,10 @@ class AppState(FreezableBaseModel):
         None,
         description="These options are passed to the terraform command, they control the terraform orchestration.",
     )
+    terraform_version: tuple[int, int] | None = Field(
+        None,
+        description="Detected terraform version as a (major, minor) tuple.",
+    )
     working_dir: Path | None = Field(
         None,
         description="The working directory is the root of where all filesystem actions are handled within the application.",
@@ -87,3 +91,4 @@ class AppState(FreezableBaseModel):
         self.providers.freeze() if self.providers else None
         self.root_options.freeze() if self.root_options else None
         self.terraform_options.freeze() if self.terraform_options else None
+        # terraform_version is a tuple, nothing to freeze

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -9,6 +9,7 @@ from tfworker.commands.config import log_limiter
 from tfworker.commands.env import EnvCommand
 from tfworker.commands.root import RootCommand
 from tfworker.commands.terraform import TerraformCommand
+import tfworker.util.terraform as tf_util
 from tfworker.util.cli import (
     handle_option_error,
     pydantic_to_click,
@@ -95,6 +96,9 @@ def terraform(ctx: click.Context, deployment: str, **kwargs):
         handle_option_error(e)
 
     ctx.obj.terraform_options = options
+    ctx.obj.terraform_version = tf_util.get_terraform_version(
+        options.terraform_bin or "terraform"
+    )
     log.info(f"building Deployment: {deployment}")
     log_limiter()
     tfc = TerraformCommand(deployment=deployment)

--- a/tfworker/util/terraform.py
+++ b/tfworker/util/terraform.py
@@ -3,7 +3,7 @@
 # the TerraformCommand class, making it easier to test and maintain
 import re
 from functools import lru_cache
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import click
 import tfworker.util.log as log
@@ -53,6 +53,19 @@ def get_terraform_version(terraform_bin: str, validation=False) -> tuple[int, in
         if validation:
             validation_exit()
         click_exit()
+
+
+def version_at_least(
+    terraform_bin: str | Tuple[int, int], major: int, minor: int
+) -> bool:
+    """Return True if the terraform version is at least the given version."""
+
+    if isinstance(terraform_bin, tuple):
+        current_major, current_minor = terraform_bin
+    else:
+        current_major, current_minor = get_terraform_version(terraform_bin)
+
+    return (current_major, current_minor) >= (major, minor)
 
 
 def mirror_providers(
@@ -189,6 +202,7 @@ def find_required_providers(
     if len(required_providers) == 0:
         return None
     return required_providers
+
 
 @lru_cache
 def quote_index_brackets(resource: str) -> str:


### PR DESCRIPTION
- add support for handling versions specific terraform differences
- update the aws backend/provider to use the version approroate locking mechanism
- fix bucket issues left over from migrating bucket operations out of the authenticator