### PR TITLE
add a results registry to handlers collection

### DIFF
--- a/tests/handlers/test_handlers_results.py
+++ b/tests/handlers/test_handlers_results.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tfworker.handlers import BaseHandler, HandlersCollection
+from tfworker.handlers.results import BaseHandlerResult
+from tfworker.types import TerraformAction, TerraformStage
+
+
+class DummyResult(BaseHandlerResult):
+    foo: int
+
+
+class DummyHandler(BaseHandler):
+    actions = [TerraformAction.PLAN]
+
+    def __init__(self):
+        self._ready = True
+
+    def execute(self, action, stage, deployment, definition, working_dir, result=None):
+        return DummyResult(handler="dummy", action=action, stage=stage, foo=1)
+
+
+class DummyDef:
+    name = "def"
+
+
+def test_results_store_and_lookup():
+    HandlersCollection._instance = None
+    hc = HandlersCollection({"dummy": DummyHandler()})
+    hc.exec_handlers(TerraformAction.PLAN, TerraformStage.POST, "dep", DummyDef(), ".")
+    assert len(hc.results) == 1
+    by_name = hc.get_results(handler_name="dummy")
+    assert by_name[0].foo == 1
+    by_field = hc.find_results("foo", 1)
+    assert by_field[0].handler == "dummy"

--- a/tfworker/handlers/__init__.py
+++ b/tfworker/handlers/__init__.py
@@ -6,3 +6,4 @@ from .s3 import S3Handler  # pragma: no cover # noqa
 from .snyk import SnykConfig, SnykHandler  # pragma: no cover # noqa
 from .sqs import QueueRule, SQSConfig, SQSHandler  # pragma: no cover # noqa
 from .trivy import TrivyConfig, TrivyHandler  # pragma: no cover # noqa
+from .results import BaseHandlerResult  # pragma: no cover # noqa

--- a/tfworker/handlers/results.py
+++ b/tfworker/handlers/results.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from tfworker.types.terraform import TerraformAction, TerraformStage
+
+
+class BaseHandlerResult(BaseModel):
+    """Base result model for handler outputs."""
+
+    handler: str
+    action: TerraformAction
+    stage: TerraformStage
+    data: dict[str, Any] | None = None
+
+    model_config = {
+        "extra": "allow",
+    }

--- a/tfworker/handlers/sqs.py
+++ b/tfworker/handlers/sqs.py
@@ -192,6 +192,16 @@ class SQSHandler(BaseHandler):
                     payload["plan"] = f.read()
             except OSError as e:  # pragma: no cover
                 log.error(f"Unable to read plan file {definition.plan_file}: {e}")
+
+        # attach handler results if available
+        try:
+            handlers = self.app_state.handlers
+            if handlers:
+                res = handlers.get_results(action=action, stage=stage)
+                if res:
+                    payload["handler_results"] = [r.model_dump() for r in res]
+        except Exception:
+            pass
         return json.dumps(payload)
 
     def _queue_urls(self) -> List[str]:


### PR DESCRIPTION
This allows handlers to register results, and give access to other handlers. The SQS and OpenAI handlers currently interact using this mechanism, adding the open AI results to message payload after actions are taken.