### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENT INSTRUCTIONS
+
+## Testing
+- This repository uses Poetry.
+- Install dependencies with `poetry install --with dev`.
+- Run tests using `poetry run pytest` or `make test`.
+
+## Linting
+- Use `poetry run flake8` or `make lint` to lint code.
+
+## Formatting
+- Use `make format` to format the code with Black and isort (or run `poetry run black` and `poetry run isort`).
+
+Always run the tests and linting after making changes and ensure the code is formatted before committing.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with guidelines for running tests, linting and formatting using Poetry and Makefile helpers

## Testing
- `make format`
- `make lint` *(fails: F401 'pytest' imported but unused)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68617c1a34c48329a00ad8597328dd71