### PR TITLE
Performance Improvements and Global Vars Fixes

### DIFF
--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -29,6 +29,22 @@ class TestLoadConfig:
         assert loaded.definitions["mod"]["path"] == "/new"
         assert "extra" in loaded.definitions
 
+    def test_parallel_options_defaults(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("""terraform:\n  definitions:\n    a:\n      path: /a\n""")
+        loaded = c.load_config(str(cfg), {"deployment": "d"})
+        assert loaded.parallel_options.max_preparation_workers == 8
+        assert loaded.parallel_options.max_init_workers == 4
+
+    def test_parallel_options_custom(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            """terraform:\n  parallel_options:\n    max_preparation_workers: 2\n    max_init_workers: 1\n  definitions:\n    a:\n      path: /a\n"""
+        )
+        loaded = c.load_config(str(cfg), {"deployment": "d"})
+        assert loaded.parallel_options.max_preparation_workers == 2
+        assert loaded.parallel_options.max_init_workers == 1
+
 
 class TestProcessTemplate:
     def test_template_vars(self, tmp_path):

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -99,7 +99,9 @@ def make_command(tmp_path, **opts_overrides):
         root_options=RootOpts(),
         loaded_config=SimpleNamespace(
             global_vars=SimpleNamespace(template_vars={}),
-            parallel_options=SimpleNamespace(max_preparation_workers=8, max_init_workers=4)
+            parallel_options=SimpleNamespace(
+                max_preparation_workers=8, max_init_workers=4
+            ),
         ),
         authenticators=[SimpleNamespace(env=lambda: {"AUTH_VAR": "1"})],
         providers="providers",
@@ -335,6 +337,175 @@ class TestTerraformCommandMethods:
         assert prepare_mock.call_count == 4
         assert init_mock.call_count == 4
 
+    def test_terraform_init_proceeds_no_local_plan_and_handler_has_plan(
+        self, tmp_path, mocker
+    ):
+        """Test that init proceeds when --no-plan is set and handler has plan available"""
+        cmd = make_command(tmp_path, plan=False, plan_file_path=None)  # --no-plan
+
+        # Mock handlers collection to indicate plan is available
+        mock_handlers = mocker.MagicMock()
+        mock_handlers.has_available_plan.return_value = True
+        cmd.app_state.handlers = mock_handlers
+
+        # Mock existing_planfile method on Definition class
+        mocker.patch(
+            "tfworker.definitions.model.Definition.existing_planfile",
+            return_value=False,
+        )
+
+        prepare_mock = mocker.patch.object(cmd, "_prepare_definition")
+        init_mock = mocker.patch.object(cmd, "_terraform_init_single")
+
+        cmd.terraform_init()
+
+        # Should prepare and init since handler has plan to apply
+        assert prepare_mock.call_count == 1
+        assert init_mock.call_count == 1
+        assert cmd.app_state.definitions["def"].needs_apply is True
+
+    def test_terraform_init_proceeds_with_local_plan_and_no_handler_plan(
+        self, tmp_path, mocker
+    ):
+        """Test that init proceeds when --no-plan is set and local plan file exists"""
+        cmd = make_command(tmp_path, plan=False, plan_file_path=None)  # --no-plan
+
+        # Mock handlers collection to indicate no plan available
+        mock_handlers = mocker.MagicMock()
+        mock_handlers.has_available_plan.return_value = False
+        cmd.app_state.handlers = mock_handlers
+
+        # Mock existing_planfile to return True (local plan exists)
+        mocker.patch(
+            "tfworker.definitions.model.Definition.existing_planfile", return_value=True
+        )
+
+        prepare_mock = mocker.patch.object(cmd, "_prepare_definition")
+        init_mock = mocker.patch.object(cmd, "_terraform_init_single")
+
+        cmd.terraform_init()
+
+        # Should prepare and init since local plan exists to apply
+        assert prepare_mock.call_count == 1
+        assert init_mock.call_count == 1
+        assert cmd.app_state.definitions["def"].needs_apply is True
+
+    def test_terraform_init_skipped_no_local_plan_and_no_handler_plan(
+        self, tmp_path, mocker
+    ):
+        """Test that init is skipped when --no-plan is set and no plans are available"""
+        cmd = make_command(tmp_path, plan=False, plan_file_path=None)  # --no-plan
+
+        # Mock handlers collection to indicate no plan available
+        mock_handlers = mocker.MagicMock()
+        mock_handlers.has_available_plan.return_value = False
+        cmd.app_state.handlers = mock_handlers
+
+        # Mock existing_planfile to return False (no local plan)
+        mocker.patch(
+            "tfworker.definitions.model.Definition.existing_planfile",
+            return_value=False,
+        )
+
+        prepare_mock = mocker.patch.object(cmd, "_prepare_definition")
+        init_mock = mocker.patch.object(cmd, "_terraform_init_single")
+
+        cmd.terraform_init()
+
+        # Should not prepare or init since no plans are available (optimization)
+        assert prepare_mock.call_count == 0
+        assert init_mock.call_count == 0
+
+    def test_terraform_init_always_proceeds_when_plan_enabled(self, tmp_path, mocker):
+        """Test that init always proceeds when planning is enabled (default behavior)"""
+        cmd = make_command(tmp_path, plan=True, plan_file_path=None)  # planning enabled
+
+        # Mock handlers collection to indicate plan is available
+        mock_handlers = mocker.MagicMock()
+        mock_handlers.has_available_plan.return_value = True
+        cmd.app_state.handlers = mock_handlers
+
+        # Mock existing_planfile to return True (local plan exists)
+        mocker.patch(
+            "tfworker.definitions.model.Definition.existing_planfile", return_value=True
+        )
+
+        prepare_mock = mocker.patch.object(cmd, "_prepare_definition")
+        init_mock = mocker.patch.object(cmd, "_terraform_init_single")
+
+        cmd.terraform_init()
+
+        # Should prepare and init even though plans exist, because planning is enabled
+        assert prepare_mock.call_count == 1
+        assert init_mock.call_count == 1
+
+
+class TestGetDefinitionsNeedingInit:
+    def test_all_definitions_when_plan_enabled(self, tmp_path, mocker):
+        """Test that all definitions are returned when planning is enabled"""
+        cmd = make_command(tmp_path, plan=True, plan_file_path=None)
+        cmd.app_state.definitions = {"def1": mock.Mock(), "def2": mock.Mock()}
+
+        result = cmd._get_definitions_needing_init()
+        assert result == ["def1", "def2"]
+
+    def test_no_plan_with_local_no_local_plan_and_handler_has_plans(
+        self, tmp_path, mocker
+    ):
+        """Test that init is needed when --no-plan is set and plans are available"""
+        cmd = make_command(tmp_path, plan=False, plan_file_path=None)
+        mock_def = mock.Mock()
+        cmd.app_state.definitions = {"def1": mock_def}
+
+        # Mock handlers to indicate plan available
+        mock_handlers = mock.Mock()
+        mock_handlers.has_available_plan.return_value = True
+        cmd.app_state.handlers = mock_handlers
+
+        # Mock existing_planfile to return False
+        mock_def.existing_planfile.return_value = False
+        mocker.patch("tfworker.definitions.plan.DefinitionPlan.set_plan_file")
+
+        result = cmd._get_definitions_needing_init()
+        assert result == ["def1"]
+        assert mock_def.needs_apply is True
+
+    def test_no_plan_with_local_plan_and_no_handler_plan(self, tmp_path, mocker):
+        """Test that init is needed when --no-plan is set and local plan exists"""
+        cmd = make_command(tmp_path, plan=False, plan_file_path=None)
+        mock_def = mock.Mock()
+        cmd.app_state.definitions = {"def1": mock_def}
+
+        # Mock handlers to indicate no plan available
+        mock_handlers = mock.Mock()
+        mock_handlers.has_available_plan.return_value = False
+        cmd.app_state.handlers = mock_handlers
+
+        # Mock existing_planfile to return True
+        mock_def.existing_planfile.return_value = True
+        mocker.patch("tfworker.definitions.plan.DefinitionPlan.set_plan_file")
+
+        result = cmd._get_definitions_needing_init()
+        assert result == ["def1"]
+        assert mock_def.needs_apply is True
+
+    def test_no_plan_with_no_local_plan_and_no_handler_plan(self, tmp_path, mocker):
+        """Test that init is skipped when --no-plan is set and no plans are available"""
+        cmd = make_command(tmp_path, plan=False, plan_file_path=None)
+        mock_def = mock.Mock()
+        cmd.app_state.definitions = {"def1": mock_def}
+
+        # Mock handlers to indicate no plan available
+        mock_handlers = mock.Mock()
+        mock_handlers.has_available_plan.return_value = False
+        cmd.app_state.handlers = mock_handlers
+
+        # Mock existing_planfile to return False
+        mock_def.existing_planfile.return_value = False
+        mocker.patch("tfworker.definitions.plan.DefinitionPlan.set_plan_file")
+
+        result = cmd._get_definitions_needing_init()
+        assert result == []
 
 
 class TestTerraformResult:

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -330,27 +330,11 @@ class TestTerraformCommandMethods:
         for i in range(2, 5):
             cmd.app_state.definitions[f"def{i}"] = cmd.app_state.definitions["def"]
         prepare_mock = mocker.patch.object(cmd, "_prepare_definition")
-        init_mock = mocker.patch.object(cmd, "_terraform_init_single_parallel")
+        init_mock = mocker.patch.object(cmd, "_terraform_init_single")
         cmd.terraform_init()
         assert prepare_mock.call_count == 4
         assert init_mock.call_count == 4
 
-    def test_terraform_init_single_parallel_captured_output(self, tmp_path, mocker):
-        cmd = make_command(tmp_path)
-        mock_pipe_exec = mocker.patch(
-            "tfworker.commands.terraform.pipe_exec",
-            return_value=(0, b"Terraform initialized successfully!", b""),
-        )
-        mock_log_info = mocker.patch("tfworker.commands.terraform.log.info")
-        mock_log_debug = mocker.patch("tfworker.commands.terraform.log.debug")
-
-        cmd._terraform_init_single_parallel("def")
-
-        mock_pipe_exec.assert_called_once()
-        args, kwargs = mock_pipe_exec.call_args
-        assert kwargs["stream_output"] is False
-        mock_log_info.assert_called_with("Terraform init completed for definition: def")
-        mock_log_debug.assert_called_with("[def] Terraform initialized successfully!")
 
 
 class TestTerraformResult:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from moto import mock_aws
 
 from tfworker.app_state import AppState
 from tfworker.authenticators import AuthenticatorsCollection
+from tfworker.backends import Backends
 from tfworker.cli_options import CLIOptionsClean, CLIOptionsRoot, CLIOptionsTerraform
 from tfworker.custom_types.config_file import ConfigFile, GlobalVars
 
@@ -46,6 +47,7 @@ def mock_cli_options_root():
     mock_root.region = "us-east-1"
     mock_root.backend_region = "us-east-1"
     mock_root.backend_bucket = "test-bucket"
+    mock_root.backend = Backends.S3
     mock_root.backend_plans = False
     mock_root.backend_prefix = "prefix"
     mock_root.create_backend_bucket = True
@@ -61,6 +63,7 @@ def mock_cli_options_root_backend_west():
     mock_root.region = "us-east-1"
     mock_root.backend_region = "us-west-2"
     mock_root.backend_bucket = "west-test-bucket"
+    mock_root.backend = Backends.S3
     mock_root.backend_plans = False
     mock_root.backend_prefix = "prefix"
     mock_root.create_backend_bucket = True

--- a/tests/handlers/test_handlers_collection_order.py
+++ b/tests/handlers/test_handlers_collection_order.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tfworker.custom_types import TerraformAction, TerraformStage
+from tfworker.exceptions import HandlerError
 from tfworker.handlers.base import BaseHandler
 from tfworker.handlers.collection import HandlersCollection
 
@@ -71,3 +72,108 @@ def test_missing_dependency_ignored():
     )
     h.exec_handlers(TerraformAction.PLAN, TerraformStage.POST, "dep", DummyDef(), ".")
     assert ORDER == ["a", "d"]
+
+
+class HandlerWithPlan(DummyHandler):
+    tag = "with_plan"
+
+    def has_plan(self, definition):
+        return True
+
+
+class HandlerWithoutPlan(DummyHandler):
+    tag = "without_plan"
+
+    def has_plan(self, definition):
+        return False
+
+
+class TestCheckPlanConflicts:
+    def test_no_conflicts_with_no_handlers_having_plans(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithoutPlan(),
+                "b": HandlerWithoutPlan(),
+            }
+        )
+        # Should not raise
+        h.check_plan_conflicts(DummyDef())
+
+    def test_no_conflicts_with_one_handler_having_plan(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": HandlerWithoutPlan(),
+            }
+        )
+        # Should not raise
+        h.check_plan_conflicts(DummyDef())
+
+    def test_conflict_with_multiple_handlers_having_plans(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": HandlerWithPlan(),
+            }
+        )
+        with pytest.raises(
+            HandlerError, match="Multiple handlers claim to have a plan"
+        ):
+            h.check_plan_conflicts(DummyDef())
+
+    def test_not_ready_handler_ignored_in_conflict_check(self):
+        handler_not_ready = HandlerWithPlan()
+        handler_not_ready._ready = False
+
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": handler_not_ready,
+            }
+        )
+        # Should not raise since handler b is not ready
+        h.check_plan_conflicts(DummyDef())
+
+
+class TestHasAvailablePlan:
+    def test_returns_false_when_no_handlers_have_plans(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithoutPlan(),
+                "b": HandlerWithoutPlan(),
+            }
+        )
+        assert h.has_available_plan(DummyDef()) is False
+
+    def test_returns_true_when_handler_has_plan(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": HandlerWithoutPlan(),
+            }
+        )
+        assert h.has_available_plan(DummyDef()) is True
+
+    def test_raises_on_conflict(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": HandlerWithPlan(),
+            }
+        )
+        with pytest.raises(
+            HandlerError, match="Multiple handlers claim to have a plan"
+        ):
+            h.has_available_plan(DummyDef())
+
+    def test_ignores_not_ready_handlers(self):
+        handler_not_ready = HandlerWithPlan()
+        handler_not_ready._ready = False
+
+        h = HandlersCollection(
+            {
+                "a": HandlerWithoutPlan(),
+                "b": handler_not_ready,
+            }
+        )
+        assert h.has_available_plan(DummyDef()) is False

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -148,6 +148,9 @@ class TerraformCommand(BaseCommand):
                 f"needs_apply value: {self.app_state.definitions[name].needs_apply}"
             )
             if self.app_state.definitions[name].needs_apply:
+                if not self._app_state.definitions[name].plan_file.exists():
+                    log.info(f"plan file does not exist for definition: {name}; skipping apply")
+                    continue
                 log.info(f"running apply for definition: {name}")
                 self._exec_terraform_action(name=name, action=action)
 
@@ -217,6 +220,9 @@ class TerraformCommand(BaseCommand):
             TerraformStage.POST,
             result,
         )
+
+        if action == TerraformAction.APPLY:
+            definition.plan_file.unlink(missing_ok=True)
 
     def _exec_terraform_pre_plan(self, name: str) -> None:
         """

--- a/tfworker/definitions/plan.py
+++ b/tfworker/definitions/plan.py
@@ -74,4 +74,8 @@ class DefinitionPlan:
             plan_file.unlink()
             return True, "empty plan file"
 
+        # Check if any handler has a plan available
+        if self._app_state.handlers.has_available_plan(definition):
+            return False, "plan available from handler"
+
         return True, "no plan file"

--- a/tfworker/definitions/prepare.py
+++ b/tfworker/definitions/prepare.py
@@ -185,7 +185,12 @@ class DefinitionPrepare:
             remotes = self._app_state.backend.remotes
         else:
             remotes = list(
-                map(lambda x: x.split(".")[0], definition.remote_vars.values())
+                map(
+                    lambda x: x.split(".")[0],
+                    definition.get_remote_vars(
+                        global_vars=self._app_state.loaded_config.global_vars.remote_vars
+                    ).values(),
+                )
             )
             log.trace(f"using remotes {remotes} for definition {name}")
         return remotes

--- a/tfworker/handlers/base.py
+++ b/tfworker/handlers/base.py
@@ -37,6 +37,17 @@ class BaseHandler(metaclass=ABCMeta):
         except AttributeError:
             return False
 
+    def has_plan(self, definition: "Definition") -> bool:  # pragma: no cover
+        """
+        has_plan is called to determine if a handler can provide an existing plan
+        for the given definition. This allows handlers to indicate they have a plan
+        available without executing the full plan workflow.
+
+        Returns:
+            bool: True if handler has a plan available for this definition
+        """
+        return False
+
     @abstractmethod
     def execute(
         self,


### PR DESCRIPTION
This PR focuses on changes made in the AffiniPay fork of the terraform-worker. These changes:

- Address issues where globally defined remote_vars were not properly inherited
- Intelligently skips terraform init process when it is uneeded work (--no-apply, and a plan exists locally or from a handler)
- Improved the handler model to be more specific about which ones may provide a plan file
- Adds parallel processing for the terraform init steps (both the worker part, and the terraform part) 