### PR TITLE
feat(terraform): add plan-failures and fail-on-plan-error toggles

### DIFF
--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -108,6 +108,8 @@ def make_command(tmp_path, **opts_overrides):
             self.plan_destroy = False
             self.plan_file_path = None
             self.limit = None
+            self.plan_failures = True
+            self.fail_on_plan_error = True
             for k, v in opts_overrides.items():
                 setattr(self, k, v)
 
@@ -460,20 +462,141 @@ class TestTerraformCommandMethods:
         cmd._exec_terraform_plan("def")
         assert cmd.app_state.definitions["def"].needs_apply
 
+        cmd.ctx.exit.reset_mock()
         mocker.patch.object(cmd, "_run", return_value=TerraformResult(1, b"", b""))
-        with pytest.raises(SystemExit):
-            cmd._exec_terraform_plan("def")
-        cmd.ctx.exit.assert_called_with(1)
+        cmd._exec_terraform_plan("def")
+        assert cmd.app_state.definitions["def"].plan_failed is True
+        cmd.ctx.exit.assert_not_called()
 
+        cmd.app_state.definitions["def"].plan_failed = False
         mocker.patch.object(cmd, "_run", return_value=TerraformResult(2, b"", b""))
         cmd._exec_terraform_plan("def")
         gen.assert_called()
         assert cmd.app_state.definitions["def"].needs_apply
 
+        cmd.app_state.definitions["def"].plan_failed = False
         cmd.app_state.handlers.exec_handlers.side_effect = HandlerError("h")
         with pytest.raises(SystemExit):
             cmd._exec_terraform_plan("def")
         cmd.ctx.exit.assert_called_with(2)
+
+    def test_exec_terraform_plan_error_dispatches_error_stage(self, tmp_path, mocker):
+        """On plan exit 1, the ERROR stage is dispatched with the failing result."""
+        cmd = make_command(tmp_path)
+        defn = cmd.app_state.definitions["def"]
+        defn.plan_file = tmp_path / "plan.tfplan"
+        mocker.patch.object(cmd, "_run", return_value=TerraformResult(1, b"error", b""))
+        mocker.patch.object(cmd, "_exec_hook")
+
+        cmd._exec_terraform_plan("def")
+
+        cmd.app_state.handlers.exec_handlers.assert_called_once()
+        call_kwargs = cmd.app_state.handlers.exec_handlers.call_args.kwargs
+        assert call_kwargs["stage"] == TerraformStage.ERROR
+        assert call_kwargs["result"].exit_code == 1
+        assert defn.plan_failed is True
+
+    def test_exec_terraform_plan_error_skips_post_hooks(self, tmp_path, mocker):
+        """POST hooks must NOT be called when plan exits with code 1."""
+        cmd = make_command(tmp_path)
+        defn = cmd.app_state.definitions["def"]
+        defn.plan_file = tmp_path / "plan.tfplan"
+        mocker.patch.object(cmd, "_run", return_value=TerraformResult(1, b"error", b""))
+        hook_mock = mocker.patch.object(cmd, "_exec_hook")
+
+        cmd._exec_terraform_plan("def")
+
+        hook_mock.assert_not_called()
+
+    def _make_two_def_command(self, tmp_path, **opts):
+        """Helper: make_command with a second definition added."""
+        cmd = make_command(tmp_path, plan=True, **opts)
+        cmd.app_state.definitions["def2"] = Definition(name="def2", path="module2")
+        return cmd
+
+    def _patch_plan_loop(self, cmd, mocker, fail_names):
+        plan_cls = mocker.patch("tfworker.definitions.plan.DefinitionPlan")
+        plan_inst = plan_cls.return_value
+        plan_inst.needs_plan.return_value = (True, "reason")
+        cmd._exec_terraform_pre_plan = mocker.Mock()
+
+        def mark(name):
+            cmd.app_state.definitions[name].plan_failed = name in fail_names
+
+        cmd._exec_terraform_plan = mocker.Mock(side_effect=mark)
+
+    def test_terraform_plan_failures_true_fail_true_halts_and_exits(
+        self, tmp_path, mocker
+    ):
+        """plan_failures=True, fail_on_plan_error=True: halts loop, exits 1."""
+        cmd = self._make_two_def_command(
+            tmp_path, plan_failures=True, fail_on_plan_error=True
+        )
+        self._patch_plan_loop(cmd, mocker, {"def"})
+
+        with pytest.raises(SystemExit):
+            cmd.terraform_plan()
+
+        assert cmd._exec_terraform_plan.call_count == 1
+        cmd.ctx.exit.assert_called_with(1)
+
+    def test_terraform_plan_failures_true_fail_false_halts_no_exit(
+        self, tmp_path, mocker
+    ):
+        """plan_failures=True, fail_on_plan_error=False: halts loop, no exit."""
+        cmd = self._make_two_def_command(
+            tmp_path, plan_failures=True, fail_on_plan_error=False
+        )
+        self._patch_plan_loop(cmd, mocker, {"def"})
+
+        cmd.terraform_plan()
+
+        assert cmd._exec_terraform_plan.call_count == 1
+        cmd.ctx.exit.assert_not_called()
+
+    def test_terraform_plan_failures_false_fail_true_continues_then_exits(
+        self, tmp_path, mocker
+    ):
+        """plan_failures=False, fail_on_plan_error=True: plans all defs, exits 1 at end."""
+        cmd = self._make_two_def_command(
+            tmp_path, plan_failures=False, fail_on_plan_error=True
+        )
+        self._patch_plan_loop(cmd, mocker, {"def"})
+
+        with pytest.raises(SystemExit):
+            cmd.terraform_plan()
+
+        assert cmd._exec_terraform_plan.call_count == 2
+        cmd.ctx.exit.assert_called_with(1)
+
+    def test_terraform_plan_failures_false_fail_false_continues_no_exit(
+        self, tmp_path, mocker
+    ):
+        """plan_failures=False, fail_on_plan_error=False: plans all defs, no exit."""
+        cmd = self._make_two_def_command(
+            tmp_path, plan_failures=False, fail_on_plan_error=False
+        )
+        self._patch_plan_loop(cmd, mocker, {"def"})
+
+        cmd.terraform_plan()
+
+        assert cmd._exec_terraform_plan.call_count == 2
+        cmd.ctx.exit.assert_not_called()
+
+    def test_terraform_plan_always_apply_skipped_on_plan_failure(
+        self, tmp_path, mocker
+    ):
+        """always_apply must not trigger apply when plan_failed=True."""
+        cmd = make_command(
+            tmp_path, plan=True, plan_failures=False, fail_on_plan_error=False
+        )
+        cmd.app_state.definitions["def"].always_apply = True
+        self._patch_plan_loop(cmd, mocker, {"def"})
+        act = mocker.patch.object(cmd, "_exec_terraform_action")
+
+        cmd.terraform_plan()
+
+        act.assert_not_called()
 
     def test_terraform_apply_or_destroy(self, tmp_path, mocker):
         cmd = make_command(tmp_path, apply=True)
@@ -737,7 +860,7 @@ class TestTerraformResult:
     def test_properties(self):
         res = TerraformResult(0, b"out", b"err")
         assert res.stdout_str == "out"
-        assert res.stderr_str == "out"
+        assert res.stderr_str == "err"
 
     def test_prep_providers_error(self, tmp_path, mocker):
         cmd = make_command(tmp_path)

--- a/tests/definitions/test_definitions_model.py
+++ b/tests/definitions/test_definitions_model.py
@@ -35,6 +35,7 @@ class TestDefinitionModel:
         assert testdef.path == "test"
         assert testdef.ready is False
         assert testdef.needs_apply is False
+        assert testdef.plan_failed is False
         assert testdef.plan_file is None
 
     def test_definition_path(self, tmp_path):

--- a/tests/handlers/test_bitbucket_handler.py
+++ b/tests/handlers/test_bitbucket_handler.py
@@ -1,0 +1,59 @@
+from unittest import mock
+
+from tfworker.commands.terraform import TerraformResult
+from tfworker.custom_types.terraform import TerraformAction, TerraformStage
+from tfworker.handlers.bitbucket import BitbucketHandler
+
+
+def make_handler():
+    handler = BitbucketHandler.__new__(BitbucketHandler)
+    handler._required = False
+    handler._pull_request = mock.Mock()
+    handler._ready = True
+    handler.config = mock.Mock()
+    handler.config.pr_text = "Terraform Plan Output for {deployment} / {definition} \n---\n\n```\n{text}\n```"
+    return handler
+
+
+class TestBitbucketHandlerExecute:
+    def test_execute_post_plan_exit_code_1_does_not_post(self):
+        """With exit_code 1, execute must not post to the pull request."""
+        handler = make_handler()
+        definition = mock.Mock()
+        definition.name = "mydef"
+        definition.deployment = "dep"
+        result = TerraformResult(1, b"error output", b"")
+
+        handler.execute(
+            action=TerraformAction.PLAN,
+            stage=TerraformStage.POST,
+            deployment="dep",
+            definition=definition,
+            working_dir="/tmp",
+            result=result,
+        )
+
+        handler._pull_request.comment.assert_not_called()
+
+    def test_execute_post_plan_exit_code_2_does_post(self):
+        """With exit_code 2, execute must still post to the pull request."""
+        handler = make_handler()
+        definition = mock.Mock()
+        definition.name = "mydef"
+        definition.deployment = "dep"
+        result = TerraformResult(
+            2,
+            b"Terraform will perform the following actions:\nPlan: 1 to add\n",
+            b"",
+        )
+
+        handler.execute(
+            action=TerraformAction.PLAN,
+            stage=TerraformStage.POST,
+            deployment="dep",
+            definition=definition,
+            working_dir="/tmp",
+            result=result,
+        )
+
+        handler._pull_request.comment.assert_called_once()

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -396,6 +396,22 @@ class TestCLIOptionsTerraform:
             ["module1.resource", "module2.resource", "module3.resource"]
         )
 
+    def test_plan_failures_default(self):
+        opts = c.CLIOptionsTerraform()
+        assert opts.plan_failures is True
+
+    def test_plan_failures_false(self):
+        opts = c.CLIOptionsTerraform(plan_failures=False)
+        assert opts.plan_failures is False
+
+    def test_fail_on_plan_error_default(self):
+        opts = c.CLIOptionsTerraform()
+        assert opts.fail_on_plan_error is True
+
+    def test_fail_on_plan_error_false(self):
+        opts = c.CLIOptionsTerraform(fail_on_plan_error=False)
+        assert opts.fail_on_plan_error is False
+
 
 class TestCLIOptionsClean:
     """

--- a/tfworker/cli_options.py
+++ b/tfworker/cli_options.py
@@ -382,6 +382,16 @@ class CLIOptionsTerraform(FreezableBaseModel):
         json_schema_extra={"env": "WORKER_BACKEND_USE_ALL_REMOTES"},
         description="Generate remote data sources based on all definition paths present in the backend",
     )
+    plan_failures: bool = Field(
+        True,
+        json_schema_extra={"env": "WORKER_PLAN_FAILURES"},
+        description="Stop planning remaining definitions when a plan error occurs (exit code 1)",
+    )
+    fail_on_plan_error: bool = Field(
+        True,
+        json_schema_extra={"env": "WORKER_FAIL_ON_PLAN_ERROR"},
+        description="Exit non-zero at end of planning if any definition had a plan error",
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -235,12 +235,23 @@ class TerraformCommand(BaseCommand):
                 continue
             log.info(f"definition {name} needs a plan: {reason}")
             self._exec_terraform_plan(name=name)
-            if getattr(self.app_state.definitions[name], "always_apply", False):
+            if (
+                self.app_state.definitions[name].plan_failed
+                and self.app_state.terraform_options.plan_failures
+            ):
+                break
+            if not self.app_state.definitions[name].plan_failed and getattr(
+                self.app_state.definitions[name], "always_apply", False
+            ):
                 log.info(
                     f"definition {name} has always_apply set; applying immediately after plan"
                 )
                 self._exec_terraform_action(name=name, action=TerraformAction.APPLY)
                 self.app_state.definitions[name].needs_apply = False
+
+        if self.app_state.terraform_options.fail_on_plan_error:
+            if any(d.plan_failed for d in self.app_state.definitions.values()):
+                self.ctx.exit(1)
 
     def terraform_apply_or_destroy(self) -> None:
         log.trace("entering terraform apply or destroy")
@@ -506,8 +517,12 @@ class TerraformCommand(BaseCommand):
 
         if result.exit_code == 1:
             log.error(f"error running terraform plan for {name}")
+            definition.plan_failed = True
+            # dispatch the ERROR stage so handlers see the failure; the plan
+            # loop decides whether to halt and the exit code is governed by
+            # fail_on_plan_error. POST success handlers/hooks are skipped.
             self._exec_error_handlers(name, TerraformAction.PLAN, result)
-            self.ctx.exit(1)
+            return
 
         if result.exit_code == 2:
             log.debug(f"terraform plan for {name} indicates changes")
@@ -708,7 +723,7 @@ class TerraformResult:
 
     @property
     def stderr_str(self) -> str:
-        return self.stdout.decode()
+        return self.stderr.decode()
 
     def log_stdout(self, action: TerraformAction) -> None:
         log_method = TerraformCommandConfig.get_config().get_log_method(action)

--- a/tfworker/definitions/model.py
+++ b/tfworker/definitions/model.py
@@ -68,6 +68,7 @@ class Definition(BaseModel):
     # Internals, these should not be set by the user
     ready: bool = False
     needs_apply: bool = False
+    plan_failed: bool = False
     plan_file: Optional[Union[str, None]] = None
 
     def get_target_path(self, working_dir: str) -> str:

--- a/tfworker/handlers/bitbucket.py
+++ b/tfworker/handlers/bitbucket.py
@@ -98,7 +98,12 @@ class BitbucketHandler(BaseHandler):
         execute is a generic method that will execute the specified action with the provided arguments.
         """
 
-        if action == TerraformAction.PLAN and stage == TerraformStage.POST:
+        if (
+            action == TerraformAction.PLAN
+            and stage == TerraformStage.POST
+            and result is not None
+            and result.exit_code == 2
+        ):
             self.plan(
                 deployment=definition.deployment,
                 definition=definition.name,
@@ -125,7 +130,7 @@ class BitbucketHandler(BaseHandler):
             # add the comment to the pull request
             try:
                 self._pull_request.comment(
-                    self.pr_text.format(
+                    self.config.pr_text.format(
                         deployment=deployment, definition=definition, text=trimmed_text
                     )
                 )


### PR DESCRIPTION
## Summary

Adds two independent boolean options to the `terraform` command controlling behavior when a terraform **plan exits with code 1** (an error, not a change). Previously the worker halted immediately on the first plan error, leaving remaining definitions unplanned.

This is a clean re-implementation of the approved plan-failures-toggle design on top of current `master`, reconciled with the `TerraformStage.ERROR` failure handling that already landed via the Slack handler work.

## Options

| Option | Default | Env var | Effect |
|---|---|---|---|
| `plan_failures` | `True` | `WORKER_PLAN_FAILURES` | Stop planning remaining definitions when a plan error occurs |
| `fail_on_plan_error` | `True` | `WORKER_FAIL_ON_PLAN_ERROR` | Exit non-zero at end of planning if any definition had a plan error |

CLI flags (`--plan-failures` / `--no-plan-failures`, `--fail-on-plan-error` / `--no-fail-on-plan-error`), env vars, and the config-file `worker_options` section are all generated automatically by existing machinery. **Defaults preserve current behavior** (halt on first error, exit 1).

**Behavioral combinations** (`fail_on_plan_error` is the sole arbiter of the exit code):

| `plan_failures` | `fail_on_plan_error` | Behavior |
|---|---|---|
| `True` (default) | `True` (default) | Halt on first plan error, exit 1 — current behavior |
| `True` | `False` | Halt on first plan error, exit 0 |
| `False` | `True` | Plan all definitions, exit 1 at end if any errored |
| `False` | `False` | Plan all definitions, exit 0 regardless |

## Implementation

- **`cli_options.py`** — the two `Field`s (flags + env vars auto-generated).
- **`definitions/model.py`** — internal `Definition.plan_failed`. The apply loop already skips definitions where `needs_apply is False`, so errored definitions are naturally excluded from apply.
- **`commands/terraform.py`** — on plan `exit_code == 1`: mark `plan_failed` and dispatch the **ERROR** stage (reusing the failure handling already on master) instead of an unconditional `ctx.exit(1)`; POST success handlers/hooks are skipped. The plan loop halts when `plan_failures` is set, and exits 1 at the end when `fail_on_plan_error` is set and any definition errored. `always_apply` no longer fires for an errored definition.

### Reconciliation note
The original design called for "always invoke POST handlers with the error result." Master now dispatches a dedicated `TerraformStage.ERROR` on failure instead, so this PR routes plan failures through ERROR rather than POST. Handlers still receive the failing result (Slack marks the definition failed); the design's handler-compatibility audit is satisfied automatically since failures no longer flow through POST.

## Also included (from the design branch)
- **`handlers/bitbucket.py`** — only post to the PR on plan changes (`exit_code == 2`), and use `self.config.pr_text`.
- **`commands/terraform.py`** — fix `TerraformResult.stderr_str` to return stderr instead of stdout.

## Testing
Built test-first. New/updated coverage:
- `test_cli_options.py` — option defaults and overrides.
- `test_definitions_model.py` — `plan_failed` default.
- `test_bitbucket_handler.py` (new) — posts on exit 2, not on exit 1.
- `test_terraform.py` — ERROR-stage dispatch on plan error, POST hooks skipped on error, all four `plan_failures`/`fail_on_plan_error` combinations, `always_apply` skipped on failure, and the `stderr_str` fix.

Full suite: **627 passed**, lint clean, coverage 86%.
