### PR TITLE
INF-6909: Improve slack handler, remote_var construction, AWS credential handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: poetry run isort --check tfworker tests
 
       - name: Lint (flake8)
-        run: poetry run flake8 --ignore E501,W503 tfworker tests
+        run: poetry run flake8 --ignore E203,E501,W503 tfworker tests
 
   test:
     name: Test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ init-dev:
 default: lint test
 
 lint: init-dev
-	poetry run flake8 --ignore E501,W503 tfworker tests
+	poetry run flake8 --ignore E203,E501,W503 tfworker tests
 
 format: init-dev
 	poetry run black tfworker tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,14 +26,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.14.0"
+version = "4.14.1"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9"},
-    {file = "anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89"},
+    {file = "anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72"},
+    {file = "anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"},
 ]
 
 [package.dependencies]
@@ -186,34 +186,34 @@ uvloop = ["uvloop (>=0.15.2) ; sys_platform != \"win32\"", "winloop (>=0.5.0) ; 
 
 [[package]]
 name = "boto3"
-version = "1.43.30"
+version = "1.43.36"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "boto3-1.43.30-py3-none-any.whl", hash = "sha256:89e982463d94773136ccf69be77cccd54ff1ce351a6aadd1d3437fcb693681b5"},
-    {file = "boto3-1.43.30.tar.gz", hash = "sha256:6b1ee360f363a457f67a8f5702f522043d8a32d67a97c362ad12075d8b5b531e"},
+    {file = "boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f"},
+    {file = "boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28"},
 ]
 
 [package.dependencies]
-botocore = ">=1.43.30,<1.44.0"
+botocore = ">=1.43.36,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.18.0,<0.19.0"
+s3transfer = ">=0.19.0,<0.20.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.43.30"
+version = "1.43.36"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "botocore-1.43.30-py3-none-any.whl", hash = "sha256:26b1dded84d89b396180916f56900bd2ab1c0d545a66d1d2c3eeb40f772935b2"},
-    {file = "botocore-1.43.30.tar.gz", hash = "sha256:19ed560cb35ae43bf010d37da429a553c07063bf7efea0f2cb53be8a78d3e3d5"},
+    {file = "botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d"},
+    {file = "botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205"},
 ]
 
 [package.dependencies]
@@ -226,14 +226,14 @@ crt = ["awscrt (==0.32.2)"]
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"},
-    {file = "certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"},
+    {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
+    {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
 ]
 
 [[package]]
@@ -475,14 +475,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"},
-    {file = "click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [package.dependencies]
@@ -503,118 +503,103 @@ markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"
 
 [[package]]
 name = "coverage"
-version = "7.14.1"
+version = "7.14.3"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf"},
-    {file = "coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332"},
-    {file = "coverage-7.14.1-cp310-cp310-win32.whl", hash = "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59"},
-    {file = "coverage-7.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253"},
-    {file = "coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f"},
-    {file = "coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9"},
-    {file = "coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548"},
-    {file = "coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e"},
-    {file = "coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3"},
-    {file = "coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c"},
-    {file = "coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a"},
-    {file = "coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1"},
-    {file = "coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e"},
-    {file = "coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a"},
-    {file = "coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793"},
-    {file = "coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33"},
-    {file = "coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c"},
-    {file = "coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416"},
-    {file = "coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42"},
-    {file = "coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d"},
-    {file = "coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54"},
-    {file = "coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1"},
-    {file = "coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce"},
-    {file = "coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1"},
-    {file = "coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee"},
-    {file = "coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d"},
-    {file = "coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee"},
-    {file = "coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7"},
-    {file = "coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343"},
-    {file = "coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1"},
-    {file = "coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd"},
-    {file = "coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e"},
-    {file = "coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c"},
-    {file = "coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af"},
-    {file = "coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2"},
-    {file = "coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be"},
+    {file = "coverage-7.14.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360bec1f58e7243e3405d3bdf7a1a8115aa9b448d54dc7cd6f7b7e0e9406b62e"},
+    {file = "coverage-7.14.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed68faa5e85de2f3e400bc3f122e5c82735a58c8bb24b9f63a2215954ba17b2d"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:830c1fca669c572dec37ce9c838224ee45aac5be0f6961edf871e82e49d6537c"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a64caee2193563601dbaaa55fe2dcf597debef04a2f8f1fa8a07aa4bb7ac7a1e"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0096fd7559178f0cc9cf088f2dbd2a02ef85bacaa69732c633517286b4494610"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6197e5a00183c11a8ce7c6abd18be1a9189fd8399084ffc95196f4f0db4f2137"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7dfe427045520d6abca33687dfef767b4f635015893a1816c5decb12eb72ce18"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9a3f142070eb7b82fc4085a55d887396f9c4e21250bccebe2ba22502c45b9647"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:64b2055bb6e0dc945af35cdeceb3633e6ed9273475ef3af85592410fd6803803"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:1551b4caac3e3ec9f2bfcec6bf3776e01c0edbdd2e240431a50ca1a1aac72c27"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:583d50d59142f8549470bd6390471d0fe8b8c8d69d6a0f28ac71e05380cef640"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0bb8a6bc7015efdf8a928753b25da1b9ca2d6f24ef04d2ee0688e486f32aae7"},
+    {file = "coverage-7.14.3-cp310-cp310-win32.whl", hash = "sha256:d48400185564042287dc487c1f016a3397f18ab4f4c5d5ec36edc218f7ffa35b"},
+    {file = "coverage-7.14.3-cp310-cp310-win_amd64.whl", hash = "sha256:eadea7aba74e40adee867a8c0eec17b820b061d308a4b014f7a0e118c2b0aa61"},
+    {file = "coverage-7.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e574801e1d643561594aa021206c46d80b257e9853087090ba97bed8b0a509d3"},
+    {file = "coverage-7.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f82b6bb7d75a2613e85d07cefa3a8c973d0544a8993337f6e2728e4a1e94c305"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2335ea5fed26af2e831094964fa3f8fae60b45f7e37fcc2d3b615b2add3ad87"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fbb8c3a98e779013786ae01d229662aeacbc77100efbd3f2f245219ace5af700"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac082660de8f429ba0ea363595abb838998570b9a7546777c60f413ab902bbde"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac012839ff7e396030f1e94e10553a431d14e4de2ab65cb3acb72bbd5628ca2"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5952f8c1bda2a5347154450379316e6dfa4d934d62ca35f6784451e6f55074fb"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8cf0f2509acb4619e2471a1951089054dd58ebea7a912066d2ea56dd4c24ca4a"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2e41fd3aab806770008279a93879b0924b16247e09ab537c043d08bbca53b4ab"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f0a47095963cfe054e0df178daca95aec21e680d6076da807c3add28dfe920f7"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a090cbf9521e78ffdb2fcf448b72902afe9f5923ff6a12d5c0d0120200348af9"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d310baf69a4fbe8a098ce727e4808a34866ac718a6f759ae659cbd3221358bc"},
+    {file = "coverage-7.14.3-cp311-cp311-win32.whl", hash = "sha256:74fdd718d88fe144f4579b8747873a07ec3f04cb837d5faec5a25d9e22fa31a8"},
+    {file = "coverage-7.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:cc96aa922e21d4bc5d5ed3c915cef27dfcbc13686f47d5e378d647fbfba655a2"},
+    {file = "coverage-7.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:c66f9f9d4f1e9712eb9b1de5310f881d4e2188cfcba5065e1a8490f38687f2c4"},
+    {file = "coverage-7.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d74ff26299c4879ce3a4d826f9d3d4d556fd285fde7bbce3c0ef5a8ab1cec24"},
+    {file = "coverage-7.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:96150a9cf3468ea20f0bc5d0e21b3df8972c31480ef90fa7614b773cc6429665"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:27d07a46500ba23515b838dbcf52512026af04090755cf6cc64166d88c9b9a1a"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:621e13c6108234d7960aaf5762ab5c3c00f33c30c15af06dcbff0c73bf112727"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b60ca6d8af70473491a15a343cbabab2e8f9ea66a4376e81c7aa24876a6f977"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c90a7cdd5e380e1ce02f19792e2ac2fbfbf177e35a27e69fd3e873b30d895c0c"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d788e5fd55347eef06ca0732c77d04a264de67e8ff24631270cdff3767a60cf"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62c7f79db2851c95ef020e5d28b97afde3daf9f7febcd35b53e05638f729063f"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:90f7608aeb5d9b60b523b9fb2a4ee1973867cc4865a3f26fe6c7577073b70205"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e3b91f9c4740aeb571ecf82e5e8d8e4ab62d34fcb5a5d4e5baa38c6f7d2857c"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c946099774a7699de03cbd0ff0a64e21aed4525eed9d959adde4afe6d15758ef"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:16b206e521feb8b7133a45754643dead0538489cf8b783b90cf5f4e3299625fd"},
+    {file = "coverage-7.14.3-cp312-cp312-win32.whl", hash = "sha256:ea3169c7116eb6cdf7608c6c7da9ecfcb3da40688e3a510fac2d1d2bafd6dc35"},
+    {file = "coverage-7.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:7ea52fc08f007bcc494d4bb3df3851e95843d881860ba38fe2c64dc100db5e7d"},
+    {file = "coverage-7.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:8cec0ad652ec57790970d817490105bd917d783c2f7b38d6b58a0ca312e1a336"},
+    {file = "coverage-7.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47968988b367990ae4ab17523790c38cd125e02c6bfd379b6022be2d40bdc38c"},
+    {file = "coverage-7.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fa9e5c6857a7e80fa22ace5cf3550ae392bbfc322f1d8dd2d2d5a8be38cec027"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:de76caefc8deabb0dd1678b6a980be97d14c8d87e213ac194dbf8b09e96d63fb"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0"},
+    {file = "coverage-7.14.3-cp313-cp313-win32.whl", hash = "sha256:338b19131ab1a6b767b462bfcbaa692e7ae22f24463e39d49b02a83410ff6b37"},
+    {file = "coverage-7.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:b3d77f7f196abdef7e01415de1bce09f216189e83e58159cfeef2b92d0464994"},
+    {file = "coverage-7.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:e6230e688c7c3e65cedd41a774eb4ec221adc6bfee13768231015b702d5e4150"},
+    {file = "coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc"},
+    {file = "coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b"},
+    {file = "coverage-7.14.3-cp314-cp314-win32.whl", hash = "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965"},
+    {file = "coverage-7.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3"},
+    {file = "coverage-7.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92"},
+    {file = "coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949"},
+    {file = "coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635"},
+    {file = "coverage-7.14.3-cp314-cp314t-win32.whl", hash = "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc"},
+    {file = "coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda"},
+    {file = "coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f"},
+    {file = "coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8"},
+    {file = "coverage-7.14.3.tar.gz", hash = "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f"},
 ]
 
 [package.extras]
@@ -2171,14 +2156,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
-    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
+    {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
+    {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
 ]
 
 [package.dependencies]
@@ -2222,14 +2207,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"},
-    {file = "pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
@@ -2587,14 +2572,14 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.0"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6"},
-    {file = "s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd"},
+    {file = "s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262"},
+    {file = "s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685"},
 ]
 
 [package.dependencies]
@@ -2859,21 +2844,20 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "tqdm"
-version = "4.68.2"
+version = "4.68.3"
 description = "Fast, Extensible Progress Meter"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede"},
-    {file = "tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add"},
+    {file = "tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03"},
+    {file = "tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482"},
 ]
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
-dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
 discord = ["envwrap", "requests"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["envwrap", "slack-sdk"]
@@ -2990,102 +2974,102 @@ test = ["pytest (>=6.0.0)", "setuptools (>=77)"]
 
 [[package]]
 name = "wrapt"
-version = "2.2.1"
+version = "2.2.2"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "wrapt-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f68f478004475d97906686e702ddbddeaf717c0b68ad2794384308f2dc713ae"},
-    {file = "wrapt-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e422b2d647a65d6b080cad5accd09055d3809bdff00c76fba8dca00ca935572a"},
-    {file = "wrapt-2.2.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:036dfb40128819a751c6f451c6b9c10172c49e4c401aebcdb8ecf2aec1683598"},
-    {file = "wrapt-2.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09ac16c081bebfd15d8e4dfa5bdc805990bbd52249ecff22530da7a129d6120b"},
-    {file = "wrapt-2.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07be671fa8875971222b0ba9059ed8b4dc738631122feba17c93aa36b4213e9a"},
-    {file = "wrapt-2.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:93fc2bf40cd7f4a0256010dce073d44eeb4a351b9bca94d0477ce2b6e62532b3"},
-    {file = "wrapt-2.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ba519b2d765df9871a25879e6f7fa78948ea59a2a31f9c1a257e34b651994afc"},
-    {file = "wrapt-2.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9011395be8db1827d106c6449b4bb6dd17e331ff6ec521f227e4588f1c78e46f"},
-    {file = "wrapt-2.2.1-cp310-cp310-win32.whl", hash = "sha256:a8f7176b83664af44567e9cc06e0d3827823fcc1a5e52307ebb8ac3aa95860b9"},
-    {file = "wrapt-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:d7f513d3185e6fec82d0c3518f2e6365d8b4e49f5f45f29640d5162d56a23b54"},
-    {file = "wrapt-2.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:44255c84bc57554fed822e83e70036b51afa9edb56fc7ca56c54410ece7898c9"},
-    {file = "wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c"},
-    {file = "wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c"},
-    {file = "wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245"},
-    {file = "wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0"},
-    {file = "wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1"},
-    {file = "wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18"},
-    {file = "wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9"},
-    {file = "wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027"},
-    {file = "wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd"},
-    {file = "wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343"},
-    {file = "wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a"},
-    {file = "wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0"},
-    {file = "wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8"},
-    {file = "wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e"},
-    {file = "wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926"},
-    {file = "wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624"},
-    {file = "wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710"},
-    {file = "wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f"},
-    {file = "wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797"},
-    {file = "wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052"},
-    {file = "wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5"},
-    {file = "wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579"},
-    {file = "wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb"},
-    {file = "wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80"},
-    {file = "wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a"},
-    {file = "wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474"},
-    {file = "wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143"},
-    {file = "wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a"},
-    {file = "wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9"},
-    {file = "wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31"},
-    {file = "wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337"},
-    {file = "wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215"},
-    {file = "wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f"},
-    {file = "wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8"},
-    {file = "wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8"},
-    {file = "wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d"},
-    {file = "wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27"},
-    {file = "wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440"},
-    {file = "wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e"},
-    {file = "wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b"},
-    {file = "wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394"},
-    {file = "wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562"},
-    {file = "wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53"},
-    {file = "wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e"},
-    {file = "wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab"},
-    {file = "wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c"},
-    {file = "wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c"},
-    {file = "wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e"},
-    {file = "wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f"},
-    {file = "wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508"},
-    {file = "wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5"},
-    {file = "wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283"},
-    {file = "wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243"},
-    {file = "wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b"},
-    {file = "wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36"},
-    {file = "wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188"},
-    {file = "wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199"},
-    {file = "wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413"},
-    {file = "wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956"},
-    {file = "wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e"},
-    {file = "wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85"},
-    {file = "wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181"},
-    {file = "wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a"},
-    {file = "wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85"},
-    {file = "wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50"},
-    {file = "wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00"},
-    {file = "wrapt-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5fa9bf3b9e66336589d03f42abce2da1055ad5c69b0c2b764852a8471c9b9114"},
-    {file = "wrapt-2.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2076d2335085eb09b9547e7688656fa8f5cf0183eab589d33499cd353489d797"},
-    {file = "wrapt-2.2.1-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7975bc88ab4b0f72ef2a2d5ae9d77d87efb5ef95e8f8046242fa9afdaaf2030b"},
-    {file = "wrapt-2.2.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61a0013344674d2b648bc6e6fe9828dd4fc1d3b4eb7523809792f8cb952e2f16"},
-    {file = "wrapt-2.2.1-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b6c0febfe38f22df2eb565c0ce8a092bb80411e56861ca382c443da83105423f"},
-    {file = "wrapt-2.2.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:211f595f8e7faae5c5930fcc64708f2ba36849e0ba0fd653a843de9fa8d7db77"},
-    {file = "wrapt-2.2.1-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:f4e1a92032a39cd5e3c647ca57dbf33b6a1938fd975623175793f9dbb63236de"},
-    {file = "wrapt-2.2.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:24c52546acf2ab82412f2ab6fc5948a7fe958d3b4f070202e8dcdd865489eaf9"},
-    {file = "wrapt-2.2.1-cp39-cp39-win32.whl", hash = "sha256:c3723ff8eb8721f4daac98bc0256f15158e05316d5e52648ce9cebee434fbdd5"},
-    {file = "wrapt-2.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:2de9e20769fe9c1f6dcdc893c6a89287c5ccf8537c90b5de78aed8017697aad5"},
-    {file = "wrapt-2.2.1-cp39-cp39-win_arm64.whl", hash = "sha256:585916e210db57b23543342c2f298e42331b617fd0c934caf5c64df44de8640e"},
-    {file = "wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f"},
-    {file = "wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9"},
+    {file = "wrapt-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:055e6fcfaa28e58c6a8c247d48b92be9d56f818b7068aa4f22b15b3343a09931"},
+    {file = "wrapt-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8374eb6b1a58809211e84ff835a182bb17ab2807a5bfef23204c8cff38178a00"},
+    {file = "wrapt-2.2.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:656593bb3f5529f03d27af4136c4d7b11990e470bcbc6fefa5ef218695bece55"},
+    {file = "wrapt-2.2.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb00cb7bb22099e2f64b7340fb96113639aa7260c0972af3797ace2297b936c"},
+    {file = "wrapt-2.2.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7f10ee0bd53673bfd52b67cbce83336fe6cad90d2377b03baf66491d2bbfb91"},
+    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4402f57c5f0d0579599858ffbdd9bf4e3f0972f51096f2bd6cc7dab6b76ee49e"},
+    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3a4eb7964ff4643d333c84f880bcf554652b2a1050aebc54ae696327f61acfaf"},
+    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e542b7c5af91e2123a8aabf19894319d5ec4268d2a9ffd2f239386133fc47746"},
+    {file = "wrapt-2.2.2-cp310-cp310-win32.whl", hash = "sha256:6e7e45b43d3c774d244fe7264378f5a3f0f383bc55a54a9866434e524540110f"},
+    {file = "wrapt-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:955f1d6e72a352e478de8d8b503abe301c5e139a141b62eb0923bd694995025f"},
+    {file = "wrapt-2.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:b89d8d73c82db2bb7e6090b3afd7973f980d24e905cc34394eab60b884b3bf67"},
+    {file = "wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73"},
+    {file = "wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e"},
+    {file = "wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d"},
+    {file = "wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328"},
+    {file = "wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5"},
+    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0"},
+    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae"},
+    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099"},
+    {file = "wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c"},
+    {file = "wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971"},
+    {file = "wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30"},
+    {file = "wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b"},
+    {file = "wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb"},
+    {file = "wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a"},
+    {file = "wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900"},
+    {file = "wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79"},
+    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a"},
+    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf"},
+    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab"},
+    {file = "wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da"},
+    {file = "wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f"},
+    {file = "wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8"},
+    {file = "wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69"},
+    {file = "wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617"},
+    {file = "wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e"},
+    {file = "wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d"},
+    {file = "wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b"},
+    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c"},
+    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f"},
+    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94"},
+    {file = "wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d"},
+    {file = "wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4"},
+    {file = "wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac"},
+    {file = "wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5"},
+    {file = "wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec"},
+    {file = "wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9"},
+    {file = "wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c"},
+    {file = "wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194"},
+    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066"},
+    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20"},
+    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af"},
+    {file = "wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9"},
+    {file = "wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28"},
+    {file = "wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0"},
+    {file = "wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745"},
+    {file = "wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00"},
+    {file = "wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc"},
+    {file = "wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95"},
+    {file = "wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33"},
+    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab"},
+    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663"},
+    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d"},
+    {file = "wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56"},
+    {file = "wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406"},
+    {file = "wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c"},
+    {file = "wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a"},
+    {file = "wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063"},
+    {file = "wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f"},
+    {file = "wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81"},
+    {file = "wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c"},
+    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff"},
+    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5"},
+    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c"},
+    {file = "wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca"},
+    {file = "wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77"},
+    {file = "wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347"},
+    {file = "wrapt-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d01d8e0afc55823245a3b97a79c7c77464e31ea7a7b629a4bf26f9441dc1f18e"},
+    {file = "wrapt-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a28287413351cb198b8c5ddd045c56fac1d195808642cd264d1ab50426146650"},
+    {file = "wrapt-2.2.2-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:abf033b7e4542357659cd83ed6cd5033c43aaa1887044045ceb571528837f72f"},
+    {file = "wrapt-2.2.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d2f6573561fa05002e5ee71529f4ab0a7dffed3e45b51013fe6298fe2723c02"},
+    {file = "wrapt-2.2.2-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c38510a21d5b9cf3e84c460d909e9f2a098667439fd42841bb081cab45835d68"},
+    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:cd385a48b055bdc3630ab30e0c7fd8514a36904ec23f9cee7a65d887334a3cea"},
+    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:3dc3dcfc2da95d501905f10dc11a0dc622e91d8cdd8bbfcb63ca54afd131e556"},
+    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:fa81c5b5fe8cd6c41e3a798533b81288279e5fdbde2128f21071922764281c99"},
+    {file = "wrapt-2.2.2-cp39-cp39-win32.whl", hash = "sha256:814f1bf3e0a7035f67a1db0cdaf5e2bbcaa4d7092db96673cfa467adeaab8591"},
+    {file = "wrapt-2.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:9ee098171b07edba66ab69a9bf0251d3cbef654107e800feb24c0c6f30592728"},
+    {file = "wrapt-2.2.2-cp39-cp39-win_arm64.whl", hash = "sha256:3179a4db066b53d40562e368b12895440c8f0953b6543b89d6acc41c0273996e"},
+    {file = "wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048"},
+    {file = "wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,26 +14,26 @@ files = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
-    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+    {file = "annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0"},
+    {file = "annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"},
 ]
 
 [[package]]
 name = "anyio"
-version = "4.14.1"
+version = "4.14.2"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72"},
-    {file = "anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"},
+    {file = "anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494"},
+    {file = "anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"},
 ]
 
 [package.dependencies]
@@ -57,14 +57,14 @@ files = [
 
 [[package]]
 name = "asttokens"
-version = "3.0.1"
+version = "3.0.2"
 description = "Annotate AST trees with source code positions"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a"},
-    {file = "asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7"},
+    {file = "asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933"},
+    {file = "asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2"},
 ]
 
 [package.extras]
@@ -186,18 +186,18 @@ uvloop = ["uvloop (>=0.15.2) ; sys_platform != \"win32\"", "winloop (>=0.5.0) ; 
 
 [[package]]
 name = "boto3"
-version = "1.43.36"
+version = "1.43.63"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f"},
-    {file = "boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28"},
+    {file = "boto3-1.43.63-py3-none-any.whl", hash = "sha256:859a8d1c50505a5cefb8629790dd34602ddb85bfd7ea5d34a362ab1793513636"},
+    {file = "boto3-1.43.63.tar.gz", hash = "sha256:647c0f0b59710ce12a49323382bb5ece1b4e02199c736d19d555330dca7e947f"},
 ]
 
 [package.dependencies]
-botocore = ">=1.43.36,<1.44.0"
+botocore = ">=1.43.63,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.19.0,<0.20.0"
 
@@ -206,14 +206,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.43.36"
+version = "1.43.63"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d"},
-    {file = "botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205"},
+    {file = "botocore-1.43.63-py3-none-any.whl", hash = "sha256:8deed86feacc8f8d2491f1d170562af191f8b33924052d834f4217d5d797e5a9"},
+    {file = "botocore-1.43.63.tar.gz", hash = "sha256:854e45247f00b0732496ea1f0c5d0cf3c31d58b48eb052c31c27ab1087dfddf1"},
 ]
 
 [package.dependencies]
@@ -222,113 +222,129 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
 
 [package.extras]
-crt = ["awscrt (==0.32.2)"]
+crt = ["awscrt (==0.36.0)"]
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
-    {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
+    {file = "certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"},
+    {file = "certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"},
 ]
 
 [[package]]
 name = "cffi"
-version = "2.0.0"
+version = "2.1.1"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
-    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
-    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
-    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
-    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
-    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
-    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
-    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
-    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
-    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
-    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
-    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
-    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
-    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
-    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
-    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
-    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
-    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
-    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
-    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
-    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
-    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
-    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
-    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
-    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
-    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
-    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
-    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
-    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
-    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
-    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
-    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
-    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
-    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
-    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
-    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
-    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
-    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
-    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
-    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
-    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
-    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
-    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
-    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
-    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
-    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
-    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
-    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
-    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
-    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
-    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
-    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
-    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
-    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
-    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
-    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
-    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
-    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
-    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
-    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
-    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
-    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
-    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
-    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
-    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
-    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
-    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
-    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
-    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
-    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
-    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
-    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
-    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
-    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
-    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
-    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
-    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
-    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
-    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
-    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
-    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
-    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
-    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
-    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
-    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+    {file = "cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be"},
+    {file = "cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9"},
+    {file = "cffi-2.1.1-cp310-cp310-win32.whl", hash = "sha256:7ce713ace7c0e4520535b42b77eaa742c16dab813978064913e5a3cf82973b41"},
+    {file = "cffi-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a48d62ab9d6f4f98c983223a547af44be6ca3691074c31cecced6facd3ba2dc1"},
+    {file = "cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12"},
+    {file = "cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa"},
+    {file = "cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3"},
+    {file = "cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0"},
+    {file = "cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455"},
+    {file = "cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0"},
+    {file = "cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf"},
+    {file = "cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517"},
+    {file = "cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735"},
+    {file = "cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e"},
+    {file = "cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a"},
+    {file = "cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80"},
+    {file = "cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e"},
+    {file = "cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c"},
+    {file = "cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6"},
+    {file = "cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2"},
+    {file = "cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b"},
+    {file = "cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7"},
+    {file = "cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac"},
+    {file = "cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d"},
+    {file = "cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973"},
+    {file = "cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c"},
+    {file = "cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb"},
+    {file = "cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54"},
+    {file = "cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96"},
+    {file = "cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527"},
+    {file = "cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13"},
+    {file = "cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c"},
+    {file = "cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48"},
+    {file = "cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836"},
+    {file = "cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3"},
+    {file = "cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676"},
+    {file = "cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e"},
+    {file = "cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f"},
+    {file = "cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4"},
+    {file = "cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e"},
+    {file = "cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5"},
+    {file = "cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d"},
+    {file = "cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b"},
+    {file = "cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4"},
+    {file = "cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399"},
+    {file = "cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688"},
+    {file = "cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7"},
+    {file = "cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac"},
+    {file = "cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960"},
+    {file = "cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1"},
+    {file = "cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc"},
+    {file = "cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6"},
+    {file = "cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94"},
+    {file = "cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5"},
+    {file = "cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66"},
+    {file = "cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3"},
+    {file = "cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692"},
+    {file = "cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be"},
 ]
 
 [package.dependencies]
@@ -336,141 +352,105 @@ pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.7"
+version = "3.4.9"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_armv7l.whl", hash = "sha256:bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-win32.whl", hash = "sha256:320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-win_amd64.whl", hash = "sha256:1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-win32.whl", hash = "sha256:8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-win_amd64.whl", hash = "sha256:12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-win_arm64.whl", hash = "sha256:bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c"},
-    {file = "charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"},
-    {file = "charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-win32.whl", hash = "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee"},
+    {file = "charset_normalizer-3.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1"},
+    {file = "charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0"},
+    {file = "charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115"},
+    {file = "charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177"},
+    {file = "charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:253a4a220747e8b5faf57ec320c4f5efb0cef05f647420bf267143ec15dba10a"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68ce9f4d6b26d5ccbf7fd4459bf75f74a0a146677ebba80597df60cbdb20e6f4"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:58150c9f9b9a552505912d182ccdf26f6396fb6094816ceebcbb20eecabaed94"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df7276909358e5635ae203673ab7e509ddd224225a8d6b0790bf13eb2bde1cc5"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c09a49d6cde137258beb3d551994a2927fd35ad5cf96aed573f61bbd67c5f84"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:231ddcbb35e2ff8973e1365db41fe0572662893b99a05deb183b68ad4c0c8bd4"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:920079c3f7456fa213e0829ed2073aaa727fd39d889ead5b4f35d0de5460d04f"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0fa1aec2d32bcc03c8fa0f6f1712caad1adc38509f31142112e5c9daf5b9c833"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ad41ba96094304aa090f5a30cb6e4fb3b3f1c264c523394b4c39bbacc4dc92ba"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:43b9e366a31fdd1c87d0eb08f579b4a82b723ea54338f040d6b4e518a026ea29"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-win32.whl", hash = "sha256:93d59d504b230e83c7a843251681959a0b6a9cd76f6e146ce1b8a80eb8739af9"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-win_amd64.whl", hash = "sha256:ddf4af30b417d9fe16481e9b81c27ab2a7cde1ff7ba3e85653b02db7d145dc7b"},
+    {file = "charset_normalizer-3.4.9-cp39-cp39-win_arm64.whl", hash = "sha256:476743fe6dfe14a2da12e3ac79125dc84a3b2cf8094369a47a1529b0cd8549fe"},
+    {file = "charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"},
+    {file = "charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b"},
 ]
 
 [[package]]
@@ -503,103 +483,103 @@ markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"
 
 [[package]]
 name = "coverage"
-version = "7.14.3"
+version = "7.15.3"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.14.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360bec1f58e7243e3405d3bdf7a1a8115aa9b448d54dc7cd6f7b7e0e9406b62e"},
-    {file = "coverage-7.14.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed68faa5e85de2f3e400bc3f122e5c82735a58c8bb24b9f63a2215954ba17b2d"},
-    {file = "coverage-7.14.3-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:830c1fca669c572dec37ce9c838224ee45aac5be0f6961edf871e82e49d6537c"},
-    {file = "coverage-7.14.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a64caee2193563601dbaaa55fe2dcf597debef04a2f8f1fa8a07aa4bb7ac7a1e"},
-    {file = "coverage-7.14.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0096fd7559178f0cc9cf088f2dbd2a02ef85bacaa69732c633517286b4494610"},
-    {file = "coverage-7.14.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6197e5a00183c11a8ce7c6abd18be1a9189fd8399084ffc95196f4f0db4f2137"},
-    {file = "coverage-7.14.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7dfe427045520d6abca33687dfef767b4f635015893a1816c5decb12eb72ce18"},
-    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9a3f142070eb7b82fc4085a55d887396f9c4e21250bccebe2ba22502c45b9647"},
-    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:64b2055bb6e0dc945af35cdeceb3633e6ed9273475ef3af85592410fd6803803"},
-    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:1551b4caac3e3ec9f2bfcec6bf3776e01c0edbdd2e240431a50ca1a1aac72c27"},
-    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:583d50d59142f8549470bd6390471d0fe8b8c8d69d6a0f28ac71e05380cef640"},
-    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0bb8a6bc7015efdf8a928753b25da1b9ca2d6f24ef04d2ee0688e486f32aae7"},
-    {file = "coverage-7.14.3-cp310-cp310-win32.whl", hash = "sha256:d48400185564042287dc487c1f016a3397f18ab4f4c5d5ec36edc218f7ffa35b"},
-    {file = "coverage-7.14.3-cp310-cp310-win_amd64.whl", hash = "sha256:eadea7aba74e40adee867a8c0eec17b820b061d308a4b014f7a0e118c2b0aa61"},
-    {file = "coverage-7.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e574801e1d643561594aa021206c46d80b257e9853087090ba97bed8b0a509d3"},
-    {file = "coverage-7.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f82b6bb7d75a2613e85d07cefa3a8c973d0544a8993337f6e2728e4a1e94c305"},
-    {file = "coverage-7.14.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2335ea5fed26af2e831094964fa3f8fae60b45f7e37fcc2d3b615b2add3ad87"},
-    {file = "coverage-7.14.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fbb8c3a98e779013786ae01d229662aeacbc77100efbd3f2f245219ace5af700"},
-    {file = "coverage-7.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac082660de8f429ba0ea363595abb838998570b9a7546777c60f413ab902bbde"},
-    {file = "coverage-7.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac012839ff7e396030f1e94e10553a431d14e4de2ab65cb3acb72bbd5628ca2"},
-    {file = "coverage-7.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5952f8c1bda2a5347154450379316e6dfa4d934d62ca35f6784451e6f55074fb"},
-    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8cf0f2509acb4619e2471a1951089054dd58ebea7a912066d2ea56dd4c24ca4a"},
-    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2e41fd3aab806770008279a93879b0924b16247e09ab537c043d08bbca53b4ab"},
-    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f0a47095963cfe054e0df178daca95aec21e680d6076da807c3add28dfe920f7"},
-    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a090cbf9521e78ffdb2fcf448b72902afe9f5923ff6a12d5c0d0120200348af9"},
-    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d310baf69a4fbe8a098ce727e4808a34866ac718a6f759ae659cbd3221358bc"},
-    {file = "coverage-7.14.3-cp311-cp311-win32.whl", hash = "sha256:74fdd718d88fe144f4579b8747873a07ec3f04cb837d5faec5a25d9e22fa31a8"},
-    {file = "coverage-7.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:cc96aa922e21d4bc5d5ed3c915cef27dfcbc13686f47d5e378d647fbfba655a2"},
-    {file = "coverage-7.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:c66f9f9d4f1e9712eb9b1de5310f881d4e2188cfcba5065e1a8490f38687f2c4"},
-    {file = "coverage-7.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d74ff26299c4879ce3a4d826f9d3d4d556fd285fde7bbce3c0ef5a8ab1cec24"},
-    {file = "coverage-7.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:96150a9cf3468ea20f0bc5d0e21b3df8972c31480ef90fa7614b773cc6429665"},
-    {file = "coverage-7.14.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:27d07a46500ba23515b838dbcf52512026af04090755cf6cc64166d88c9b9a1a"},
-    {file = "coverage-7.14.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:621e13c6108234d7960aaf5762ab5c3c00f33c30c15af06dcbff0c73bf112727"},
-    {file = "coverage-7.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b60ca6d8af70473491a15a343cbabab2e8f9ea66a4376e81c7aa24876a6f977"},
-    {file = "coverage-7.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c90a7cdd5e380e1ce02f19792e2ac2fbfbf177e35a27e69fd3e873b30d895c0c"},
-    {file = "coverage-7.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d788e5fd55347eef06ca0732c77d04a264de67e8ff24631270cdff3767a60cf"},
-    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62c7f79db2851c95ef020e5d28b97afde3daf9f7febcd35b53e05638f729063f"},
-    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:90f7608aeb5d9b60b523b9fb2a4ee1973867cc4865a3f26fe6c7577073b70205"},
-    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e3b91f9c4740aeb571ecf82e5e8d8e4ab62d34fcb5a5d4e5baa38c6f7d2857c"},
-    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c946099774a7699de03cbd0ff0a64e21aed4525eed9d959adde4afe6d15758ef"},
-    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:16b206e521feb8b7133a45754643dead0538489cf8b783b90cf5f4e3299625fd"},
-    {file = "coverage-7.14.3-cp312-cp312-win32.whl", hash = "sha256:ea3169c7116eb6cdf7608c6c7da9ecfcb3da40688e3a510fac2d1d2bafd6dc35"},
-    {file = "coverage-7.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:7ea52fc08f007bcc494d4bb3df3851e95843d881860ba38fe2c64dc100db5e7d"},
-    {file = "coverage-7.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:8cec0ad652ec57790970d817490105bd917d783c2f7b38d6b58a0ca312e1a336"},
-    {file = "coverage-7.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47968988b367990ae4ab17523790c38cd125e02c6bfd379b6022be2d40bdc38c"},
-    {file = "coverage-7.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a"},
-    {file = "coverage-7.14.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fa9e5c6857a7e80fa22ace5cf3550ae392bbfc322f1d8dd2d2d5a8be38cec027"},
-    {file = "coverage-7.14.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73"},
-    {file = "coverage-7.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9"},
-    {file = "coverage-7.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de"},
-    {file = "coverage-7.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd"},
-    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5"},
-    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:de76caefc8deabb0dd1678b6a980be97d14c8d87e213ac194dbf8b09e96d63fb"},
-    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f"},
-    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498"},
-    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0"},
-    {file = "coverage-7.14.3-cp313-cp313-win32.whl", hash = "sha256:338b19131ab1a6b767b462bfcbaa692e7ae22f24463e39d49b02a83410ff6b37"},
-    {file = "coverage-7.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:b3d77f7f196abdef7e01415de1bce09f216189e83e58159cfeef2b92d0464994"},
-    {file = "coverage-7.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:e6230e688c7c3e65cedd41a774eb4ec221adc6bfee13768231015b702d5e4150"},
-    {file = "coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc"},
-    {file = "coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7"},
-    {file = "coverage-7.14.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce"},
-    {file = "coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5"},
-    {file = "coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a"},
-    {file = "coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501"},
-    {file = "coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e"},
-    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3"},
-    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5"},
-    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845"},
-    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027"},
-    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b"},
-    {file = "coverage-7.14.3-cp314-cp314-win32.whl", hash = "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965"},
-    {file = "coverage-7.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3"},
-    {file = "coverage-7.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92"},
-    {file = "coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949"},
-    {file = "coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891"},
-    {file = "coverage-7.14.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388"},
-    {file = "coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784"},
-    {file = "coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed"},
-    {file = "coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5"},
-    {file = "coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26"},
-    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889"},
-    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d"},
-    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e"},
-    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7"},
-    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635"},
-    {file = "coverage-7.14.3-cp314-cp314t-win32.whl", hash = "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc"},
-    {file = "coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda"},
-    {file = "coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f"},
-    {file = "coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8"},
-    {file = "coverage-7.14.3.tar.gz", hash = "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f"},
+    {file = "coverage-7.15.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3a82b2ceee91ba353e59fe2436d8a9eae799ff9825e5385423ea205d693e2949"},
+    {file = "coverage-7.15.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3088cce65e54c2eefc08e7e1ca0b0acec1e95e8cf084ac848599103ed0367f74"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a65e09efb0b5ab21fc54a8a65c5b2e533c0a4c0d064af0259a005dc656dc1b13"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b51f279a2477b0e1f288b98f141fd227acfdd1d3f0370400e473788879b47871"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7835176988cbcf1f014db683bc33aa15e0558e412bf08deaa99757335b88df15"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f24896dc8863167f6732f4142f5d37e6195eccc8fe5fe528d35d49597d29fdb3"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9490d43e5d041fdf376770a886a29722adb05f6b9c21a65c48c81fc8f1c33fd7"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:225e359bd5dedaff6d68e36091af20555866c557d968167308b677379bf575c3"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:22119e2e3b2ac5ac024d50131fdd4b22ab4c6cf8aa2fc792cce73c0d94c5812d"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:12d555badc462b0f6037ce8bec8b4af8d71f90eb55b57d0a358731f7ee7883e2"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c4e2cf9cf774939b3dc581c6e31dfe7e8d7608b24f0f17524d6161f8235c3d2c"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cea1b3e19d710f67e2ba9ce0b0b51032c2a9b4808a65ced48ddf336ef7e58058"},
+    {file = "coverage-7.15.3-cp310-cp310-win32.whl", hash = "sha256:25c77560309f157e7b7ee8fe0bf78d047ba900b7ae42f0e50e559305b366fea2"},
+    {file = "coverage-7.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:179fbf847e6c3d90ea71bfd570fe57f1ddb1c51474754894871c1e11099efaa0"},
+    {file = "coverage-7.15.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5f3f854ab4599d98f7799ac9b91e34e8ec9ebc9a6372ee8c1f3413a68cc8b5e9"},
+    {file = "coverage-7.15.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75268348fee1f199653b8a846262aec5581c6bb008c4f58824959fb708cc688f"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:21081739f6264cc594cad2d42b62befbd17633824022866c68720eb0c4b8d6b4"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:718d366251b060c10731c7dd359de6caea72250036eb94576aa56dacbf830a11"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa1bbaa502a6e877f3ee67cbac3eba2bb637f623e454e6c37b81b38896dbd48f"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:494880c9e60782610683f4eb9b65cce4f886673596b8f3cb2dfa079fc551c743"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3db264ea689f9e8f9fa4fb9005fee4048c3bff4a547f4cfa27f5086cb0804ec0"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4e869d4799674d67778e76ddbe2e26cf1673369262e231a8ec259421b1015fea"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:696fc7a28bbf717aba8d2c6963d26702945c7832cb313ba3b323aa5b1afb3156"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:3fe9be1c527497d047f770d88a0110189714c36383bb88384508f750c302bffa"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2400591f4b2e33746c70846388f8bb4c7e33b820e31cb8c6cb2f25305310438b"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2e557178799282269412a672e5753f2179edfe1b3f0f19b0c98f8e72d482326a"},
+    {file = "coverage-7.15.3-cp311-cp311-win32.whl", hash = "sha256:68ea6c947375982ae907e19e9d2ef156bd6e68e11f3566dd568d7f4ec974e715"},
+    {file = "coverage-7.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:28743dad31622e8c474b17446118037361f5b1f4f2ecdf72d4f6fde246d64446"},
+    {file = "coverage-7.15.3-cp311-cp311-win_arm64.whl", hash = "sha256:c4398918c4fda32718191239e451fd86ac5ad1e8979b592f1921ee2d1f038965"},
+    {file = "coverage-7.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:79a3e32e83227d83d9684459ed579769b56c369ac2d7313099b2d9e031d2e10f"},
+    {file = "coverage-7.15.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:767feb87c5886d781d0a69fafd450a20826ddab7b79bce1665deb64d21441b60"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:50951e37033c40548d777b8a8454a2cd622dba1136780065678dccaec307c47f"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:63a4ff67364afb2cac826b8bbd78a5c50ce656a7b7137436b44d7b96a9271088"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e95e42856509675fe26560310313a6117640e96f9a1e19bb3d220116a27c94c"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:abad631cba27094b4631993f4c72e89ac0ca1b3a0236c7abaf8ca79aea619851"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b0807f1f051dd82a234ad6acdb6f1425baede60be1e84e862496c8cc9262ab9"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d8d6df7aeb5bc464040bbc9ae173d875785d3677ebc4307817997d622d74225e"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:974471c506c9f5758808b47c1ebf7949ecd0848f5c1020e78675fefe5ff46866"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5cba0c9c13e35c86df7998f1afaf6b1da224a3a39e4da59bdabf60c148046dcb"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4d608dc36a364dce33acbf4fc3a50f9d2054c945f233bb0a2cdb4b90bfa17646"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2395869280554a1941da904423c12660c39f721315e1c02d076a7fe0971382f0"},
+    {file = "coverage-7.15.3-cp312-cp312-win32.whl", hash = "sha256:24f3b21840c3eb76cef3cc70b2bf6649010c64471a84a446538a39306e1ba04d"},
+    {file = "coverage-7.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:fa7b17902c3c1dd8a7adb52679b7f6340bba08443d710c8838e04db8cf62be2a"},
+    {file = "coverage-7.15.3-cp312-cp312-win_arm64.whl", hash = "sha256:fcbe83fb7258eacd293bf5322d88807acb35ed12a5cfa99dd8215c083e3b0235"},
+    {file = "coverage-7.15.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1182eed05674c63d40951fae27c43e822749f04d25f75df64c2e4fa3168678de"},
+    {file = "coverage-7.15.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c0c4b0d7c4cd56e470d0c9d8441f42e8a96cdfd95050fec027f1d4dd9f11006c"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5c9fce9f4998b0d50a753da765b9215a14decc7863822c89d72da7a89ca625b3"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7a47e2a0a0ace9241e70ee00e44520f88b843094603dd54303f1bafecd929c30"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95bad94f83807ae60ed76f3ac012f69b2605ac9ea81bee959a5a483f7fa09c10"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:228e172a76c428bb17d1ab78a2ff188990b0597e5dbd291f52a4edf7412de049"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cea9fb33887c99349996266f1fd60abe5af3577a90633392001d27ef46b4b66e"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:81760de3155d7f52c21860c4046628dc6bed182f72e3c028e2b4fd46f65aa040"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b47ea0a1d3a3d089826c6cbfad8429d7d8872e28e86baa95ddef330f6875da21"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5459ba486b2a5d58a6c05254779ecdf525e7f20174d0210ceda75ba40fdb8f2c"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c59209f80a08dbfcdd5109a80dc623cd3b9d22895c85757d34f57a6e6e95570f"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f863856c1779d4a5bb6a94698a2f9073e09c6706501f76f3e7780e72df97d21c"},
+    {file = "coverage-7.15.3-cp313-cp313-win32.whl", hash = "sha256:00cbdc5e322927dc30c5e42b863819b1bb867cc66f26ab5372c585850876ab93"},
+    {file = "coverage-7.15.3-cp313-cp313-win_amd64.whl", hash = "sha256:835528518a1d823cf336740324b2f335f7c01e609e74abcb5d5163b3e66661e3"},
+    {file = "coverage-7.15.3-cp313-cp313-win_arm64.whl", hash = "sha256:0d2e1f2cbbf36b842f3e2aff8d118c60d677adb498bc6c7fa9c6838738f82767"},
+    {file = "coverage-7.15.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1e3bb08ad574bd9fb6a991f645728f70d333c1c1958dd5fcde65e24cb862813d"},
+    {file = "coverage-7.15.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9e5860eaff02a0b7f1b73304bdf846596ee62ab3a78d25c68044ebf684cb1fef"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:60874e5bd67f0b1bdbe42ab42c7bafa66a6fb8de88721af6df3f7a02713960cd"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9147be876e9d83765e0b82176674dc248a6b9283e25e01e7462611b97e9b731"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61a01f8c3804760fcc5a3d31c4f3cab792d660d44e17bf7adeaf0ea51e07821e"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95bf3e7f26f792e25eb185f85a5a659d48479265176dcfe22b6f334fd0081b5c"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:44c41eff9e413fed8740eca75d5438ebeb9d3e45e7cd37c67329213e7a72c764"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54146bafb61f3ba9895b43af0dd17eba01561d586d44ce84ea221b0cbbee5a9e"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:af000dd1bb859ff8066fda4c79512ff938c798116540307226b373099c7b151f"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a1b82490577f3889950b5a04f18712aef0207243e0749d60fe28c3c73ebfd5fd"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:c4fc90a60154c3e4b8a2dc206d6dbe852f1c235c249e0dc0cef909d032c9591a"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f25bb884814a892948b4c20394db3f2364dd452d9492736479e7a493e63b0eb6"},
+    {file = "coverage-7.15.3-cp314-cp314-win32.whl", hash = "sha256:722dbf8e7828fbcfe0dc8586167dc0a5ce85ad6ea171dbb21ed3f8d6581d3cb8"},
+    {file = "coverage-7.15.3-cp314-cp314-win_amd64.whl", hash = "sha256:64d0845f9c3ed47302bed265c15ab4dbb64aa4ec1490839b8e328f4e7fa914d2"},
+    {file = "coverage-7.15.3-cp314-cp314-win_arm64.whl", hash = "sha256:69bc14684f8fbbee9f9dbaa4fe79719b0da9725fc37956785c06ec365acf6926"},
+    {file = "coverage-7.15.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f92df943c24b96cb215ca26b4f6a2283e63c5db80f1635aceea7fff11311917b"},
+    {file = "coverage-7.15.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:66591c46bdd2971d3ae2bc503a5f0459c2edcaf6b7e045b292000cc95bc6cb95"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa64458b81b18bfc67cdf1f6dc02b23e3edc672f2f8e11771fad75865415a43"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:447f5421ccf5475956cf516d4ca1d575f487947b6f4e11f9d80c6aefe24b3dc8"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a0c77ef8cd483a4987a5d12d1d9d5f7ee598dfdc6c0844417d847e5768dc779"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0b273f4ff657446a06c2d85bf80e134fa869a92852ba5f87854a70e1fb44da77"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daea8c4fafa22488600405be2c2be525a9406fba3fc0a83acc726db3e14e2005"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:93ff57c530f3fa7aa69f92fb9b8892b8aa82712aa970842f4abf28657f42fb57"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4df21bef8b800eebda9018f53d49c9ace3aeb0090c850139b27923aafcb83e91"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:db567b02685f26034adcbd85055f80d12cdf02111b8ed00886093d98b2874ce2"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5318dd51b8600b947e058cf5a4fe54d183d9d13c49b97b64ca7be05a34df9bef"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c995bfa383c54704839b6c4c2627a1c00895597ada0e5e8190c81d8bd620555c"},
+    {file = "coverage-7.15.3-cp314-cp314t-win32.whl", hash = "sha256:6433fafb8da0e1d02eb53411e0ecdadb6b88f0224fdc23317e703c0e88937d42"},
+    {file = "coverage-7.15.3-cp314-cp314t-win_amd64.whl", hash = "sha256:fe578952b1b29fe8c777f43f241d49efac4b56724a3434f5d22ebe3c208df429"},
+    {file = "coverage-7.15.3-cp314-cp314t-win_arm64.whl", hash = "sha256:d2e1acb7aee29dfa8f3e48c23f36670898baca1209d9bdd3985a50c7f982165e"},
+    {file = "coverage-7.15.3-py3-none-any.whl", hash = "sha256:da78fa6fc7dafe4212839173133ee85afcf42c5cd5f3e47fa7c1c210453b445e"},
+    {file = "coverage-7.15.3.tar.gz", hash = "sha256:ae7ea5a4614acf399ef0483c4cb34f8f8f01df848d8fcbe7d3ce0865733f1c4d"},
 ]
 
 [package.extras]
@@ -607,58 +587,58 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "49.0.0"
+version = "50.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9"},
-    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f"},
-    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459"},
-    {file = "cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e"},
-    {file = "cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8"},
-    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3"},
-    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27"},
-    {file = "cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61"},
-    {file = "cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36"},
-    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e"},
-    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b"},
-    {file = "cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6"},
-    {file = "cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493"},
+    {file = "cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f"},
+    {file = "cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105"},
+    {file = "cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef"},
+    {file = "cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30"},
+    {file = "cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c"},
+    {file = "cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c"},
+    {file = "cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95"},
+    {file = "cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269"},
+    {file = "cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47"},
+    {file = "cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9"},
+    {file = "cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7"},
+    {file = "cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba"},
+    {file = "cryptography-50.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5e34edd123674534acd70147f0ca331eaa2c74e6325fb2028c886aa26ba0b68c"},
+    {file = "cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5e1172eb569ea8a872796576e6a67c276351728b6455d5beb01242b027c6a"},
+    {file = "cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:910d11e1a385c654bf738bf3e6b8e6ed5de0f5610fcae2be9e5b398d8081d20e"},
+    {file = "cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:62598a8a57f815db4c6259a4e97d857dab56697e7de8e8ab02352ab74da1995d"},
+    {file = "cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:07479a1cb08219ab719147e742e76090c9c773321959bb94946fffdd397a6437"},
+    {file = "cryptography-50.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c99c003e088647b8a5b7c145d6f78c335f6348332b62e142d411c4b63d1460b9"},
+    {file = "cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9"},
 ]
 
 [package.dependencies]
@@ -735,14 +715,14 @@ files = [
 
 [[package]]
 name = "docker"
-version = "7.1.0"
+version = "7.2.0"
 description = "A Python library for the Docker Engine API."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0"},
-    {file = "docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c"},
+    {file = "docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f"},
+    {file = "docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac"},
 ]
 
 [package.dependencies]
@@ -802,14 +782,14 @@ pyflakes = ">=3.4.0,<3.5.0"
 
 [[package]]
 name = "google-api-core"
-version = "2.31.0"
+version = "2.33.0"
 description = "Google API client core library"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab"},
-    {file = "google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2"},
+    {file = "google_api_core-2.33.0-py3-none-any.whl", hash = "sha256:a2e22a0c1d0f03eafff1858b38cf46f832d5902b0c052235bf0ab8402929fbdc"},
+    {file = "google_api_core-2.33.0.tar.gz", hash = "sha256:3a36bcc3e319783f4c97da41f6f45ea6ffcaa55848e341de16e09cb70243c2bb"},
 ]
 
 [package.dependencies]
@@ -828,31 +808,35 @@ grpc = ["grpcio (>=1.41.0,<2.0.0)", "grpcio (>=1.49.1,<2.0.0) ; python_version >
 
 [[package]]
 name = "google-auth"
-version = "2.55.0"
+version = "2.56.2"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a"},
-    {file = "google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb"},
+    {file = "google_auth-2.56.2-py3-none-any.whl", hash = "sha256:c8270ea95b2697b74e3d8438ae9c5b898e38b623b915c7b5c5635921e7de68a6"},
+    {file = "google_auth-2.56.2.tar.gz", hash = "sha256:e28f103ca8091fb7012b99c44243d7366c29863713b8e34a220c3322b7a07051"},
 ]
 
 [package.dependencies]
-cryptography = ">=38.0.3"
+cryptography = [
+    {version = ">=38.0.3", markers = "python_version < \"3.14\""},
+    {version = ">=41.0.5", markers = "python_version >= \"3.14\""},
+]
 pyasn1-modules = ">=0.2.1"
 
 [package.extras]
-aiohttp = ["aiohttp (>=3.8.0,<4.0.0)", "requests (>=2.20.0,<3.0.0)"]
-cryptography = ["cryptography (>=38.0.3)"]
-enterprise-cert = ["pyopenssl"]
+aiohttp = ["aiohttp (>=3.8.0,<4.0.0) ; python_version < \"3.14\"", "aiohttp (>=3.9.0,<4.0.0) ; python_version >= \"3.14\"", "requests (>=2.30.0,<3.0.0)"]
+cryptography = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
+enterprise-cert = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
+grpc = ["grpcio (>=1.59.0,<2.0.0) ; python_version < \"3.14\"", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\""]
 pyjwt = ["pyjwt (>=2.0)"]
-pyopenssl = ["pyopenssl (>=20.0.0)"]
+pyopenssl = ["cryptography (>=38.0.3) ; python_version < \"3.14\"", "cryptography (>=41.0.5) ; python_version >= \"3.14\""]
 reauth = ["pyu2f (>=0.1.5)"]
-requests = ["requests (>=2.20.0,<3.0.0)"]
-rsa = ["rsa (>=3.1.4,<5)"]
-testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.8.0,<4.0.0)", "aioresponses", "flask", "freezegun", "grpcio", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
-urllib3 = ["packaging", "urllib3"]
+requests = ["requests (>=2.30.0,<3.0.0)"]
+rsa = ["rsa (>=4.0.0,<5)"]
+testing = ["aiohttp (>=3.8.0,<4.0.0) ; python_version < \"3.14\"", "aiohttp (>=3.9.0,<4.0.0) ; python_version >= \"3.14\"", "aioresponses", "flask", "freezegun", "grpcio (>=1.59.0,<2.0.0) ; python_version < \"3.14\"", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\"", "packaging (>=20.0)", "pyjwt (>=2.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.30.0,<3.0.0)", "responses", "urllib3 (>=1.26.15,<3.0.0)"]
+urllib3 = ["packaging (>=20.0)", "urllib3 (>=1.26.15,<3.0.0)"]
 
 [[package]]
 name = "google-cloud-core"
@@ -1181,121 +1165,117 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jiter"
-version = "0.15.0"
+version = "0.16.0"
 description = "Fast iterable JSON parser."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "jiter-0.15.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:edebcf7d1f601199084bb6e844d7dc67e03e04f6ac786b0332d616635c4ff7a4"},
-    {file = "jiter-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f924585cdacf631cd382b657966847bb537bf9ed0a6f9b991da5f05a631480f"},
-    {file = "jiter-0.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abbf258599526ad0326fe51e252e24f2bd6f24f1852681b4b78feda3808f1d18"},
-    {file = "jiter-0.15.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7c468136b8bd6bb18c8786e4236a1fa27362f24cb23450ba0cb204ab379b8e6f"},
-    {file = "jiter-0.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05906b93d72f03339e6bb7cf8dc10ebda64a0266126eed6beba79e20abcf5fd4"},
-    {file = "jiter-0.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30ce785d2adb8e32c3f7741442370a74834ec4c01f3c48f0750227a0b4ef27d6"},
-    {file = "jiter-0.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd73e3da91a0a722d67165e849ce2cdc10de0e0d48738c142be8c6c5f310f4c"},
-    {file = "jiter-0.15.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:ceb8fc27d38793f9c97149be8302720c5b22e5c195a37bf2c45dc36c4600a512"},
-    {file = "jiter-0.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d726e3ceeb337191324b49de298142f27c3ad10886341555d1d5315b5f252c6a"},
-    {file = "jiter-0.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c8aea7781d2a372227871de4e1a1332aa96f5a89fd76c5e835dafdbad102887"},
-    {file = "jiter-0.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cf4bd113a69c0a740e27cb962ce10630c36d2b8f59d759a651b955ee9d18a823"},
-    {file = "jiter-0.15.0-cp310-cp310-win32.whl", hash = "sha256:d92a5cd21fdb083931d546c207aa29633787c5dc5b02daab2d32b843f88a2c53"},
-    {file = "jiter-0.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:e58585a58209d72691ce2d62a9147445f5a87beb0bde97fde284c96ae392a3d1"},
-    {file = "jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2"},
-    {file = "jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67"},
-    {file = "jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a"},
-    {file = "jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7"},
-    {file = "jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd"},
-    {file = "jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281"},
-    {file = "jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708"},
-    {file = "jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928"},
-    {file = "jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd"},
-    {file = "jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e"},
-    {file = "jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef"},
-    {file = "jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32"},
-    {file = "jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04"},
-    {file = "jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865"},
-    {file = "jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d"},
-    {file = "jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0"},
-    {file = "jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138"},
-    {file = "jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61"},
-    {file = "jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687"},
-    {file = "jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879"},
-    {file = "jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d"},
-    {file = "jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb"},
-    {file = "jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871"},
-    {file = "jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77"},
-    {file = "jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d"},
-    {file = "jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d"},
-    {file = "jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7"},
-    {file = "jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b"},
-    {file = "jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3"},
-    {file = "jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5"},
-    {file = "jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279"},
-    {file = "jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4"},
-    {file = "jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258"},
-    {file = "jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894"},
-    {file = "jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45"},
-    {file = "jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29"},
-    {file = "jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b"},
-    {file = "jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7"},
-    {file = "jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712"},
-    {file = "jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c"},
-    {file = "jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0"},
-    {file = "jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba"},
-    {file = "jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8"},
-    {file = "jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c"},
-    {file = "jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4"},
-    {file = "jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b"},
-    {file = "jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7"},
-    {file = "jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49"},
-    {file = "jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86"},
-    {file = "jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f"},
-    {file = "jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e"},
-    {file = "jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6"},
-    {file = "jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9"},
-    {file = "jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c"},
-    {file = "jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd"},
-    {file = "jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89"},
-    {file = "jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554"},
-    {file = "jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a"},
-    {file = "jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec"},
-    {file = "jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558"},
-    {file = "jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866"},
-    {file = "jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d"},
-    {file = "jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6"},
-    {file = "jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995"},
-    {file = "jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8"},
-    {file = "jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5"},
-    {file = "jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b"},
-    {file = "jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8"},
-    {file = "jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec"},
-    {file = "jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e"},
-    {file = "jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5"},
-    {file = "jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52"},
-    {file = "jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854"},
-    {file = "jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0"},
-    {file = "jiter-0.15.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:04b400bbf8c9efb03d9bdd976475c919c1d85593b04b9fff7ae234065daf87ae"},
-    {file = "jiter-0.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25ffbe229aa8cd98c28879d8aa1a6e34ae77992ab984a65fba800859dab16269"},
-    {file = "jiter-0.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5607e6013ed7e6b0ec9661e467b7ffde0aa7ab36833a04850f26fcf88ed4845b"},
-    {file = "jiter-0.15.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50164d7610c00e7cd913a873fce30b6beeebf4b37e53983e33f22de4c900f6b8"},
-    {file = "jiter-0.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ab596fa3837e91e7e6a31b5f639988bfc6a35d1f915ac3932d946062219d588f"},
-    {file = "jiter-0.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d72d8af5c1013656a8870c866660627d1a75bc185814ee022c8533caa1de88ae"},
-    {file = "jiter-0.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c84c1b7be454b0c16f8499b4ebfbfd82ea5cca6527cceefcbbc06a7557b5ed2e"},
-    {file = "jiter-0.15.0-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:d636d5095155afd364247f65070fab7beda13498d7ff4de331046e704ab9657f"},
-    {file = "jiter-0.15.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d3d6683288c11cbab50e865f2e2f13950179aa45410e30b2cfbd3fb7b0177bf"},
-    {file = "jiter-0.15.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7ce8902f939970048b233087082e7bb829db29375811c7ad50687b8624c6fd08"},
-    {file = "jiter-0.15.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4363818355dbc70ae1a8e9eaba9de350d93ede4ff6992b8f8eb8cbb6e5122d42"},
-    {file = "jiter-0.15.0-cp39-cp39-win32.whl", hash = "sha256:8f7e9bc0f1135039b22ee6eab588d42df1ce55842b30740a352885eb267bd941"},
-    {file = "jiter-0.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:1c15024a3d892223b18f597c86d59387249dc396590844ce6b9f6131d1093bae"},
-    {file = "jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750"},
-    {file = "jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b"},
-    {file = "jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b"},
-    {file = "jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c"},
-    {file = "jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0"},
-    {file = "jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45"},
-    {file = "jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c"},
-    {file = "jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a"},
-    {file = "jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76"},
+    {file = "jiter-0.16.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fc4f8def331036a7b8e981b4347ebe409981edbc8308a5ea842b8c3614fa6c"},
+    {file = "jiter-0.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5a71d0d2014c3275043e1170bf3d4e771493cb0dcf07be54c567155f4d8ee64b"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:741eed508c233a76313a1c7b001f8f21b82f14327e9196ae8bd29a2cc164ae84"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb7bc819187b56dc48aa5c833aaf92257da8e07efdb9306156667bd2eeb491c"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c9610fd25ebccb43fca584136f5c2fbb26802447eccd430dfdbab95a0fd5126"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a1d68ff7ca1d3b5dee20a97a3decda7d5f15003823bf6d140c81f8561d3bc5c"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb08c276dd02dac3a284acdd02cacc630d2e3cd6572a4b85519f35cbd133c3de"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:8fc4d94713c4697347e38faf7d6ef91547c142219bdcfc7220c4870879974244"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a0f05e229edb29e68cdd0ccb83cea13b64263416120cf943767a6fd72e6787f"},
+    {file = "jiter-0.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c842cbf374a8daf50b2c04212995bee34ca2ac2cdc29a901b4cdb072c9c4131"},
+    {file = "jiter-0.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5ed466aee31294d7cdcd4d37dfe5c42c97bc29d9a5f00eacf24504358309cb9b"},
+    {file = "jiter-0.16.0-cp310-cp310-win32.whl", hash = "sha256:b42e9ff5376819c053da25809a8d4b6fa6e473b4856ebe42e298ac958be3d7f9"},
+    {file = "jiter-0.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:10438939205546132189c8e74a2d536a707841f3a25cd7c74ee91fe503407a26"},
+    {file = "jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3"},
+    {file = "jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea"},
+    {file = "jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91"},
+    {file = "jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3"},
+    {file = "jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7"},
+    {file = "jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1"},
+    {file = "jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056"},
+    {file = "jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a"},
+    {file = "jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5"},
+    {file = "jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730"},
+    {file = "jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f"},
+    {file = "jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274"},
+    {file = "jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7"},
+    {file = "jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331"},
+    {file = "jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195"},
+    {file = "jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e"},
+    {file = "jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb"},
+    {file = "jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84"},
+    {file = "jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e"},
+    {file = "jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd"},
+    {file = "jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a"},
+    {file = "jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee"},
+    {file = "jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93"},
+    {file = "jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a"},
+    {file = "jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00"},
+    {file = "jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe"},
+    {file = "jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106"},
+    {file = "jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8"},
+    {file = "jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585"},
+    {file = "jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e"},
+    {file = "jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077"},
+    {file = "jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734"},
+    {file = "jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf"},
+    {file = "jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db"},
+    {file = "jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce"},
+    {file = "jiter-0.16.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:d8f80521644426d451e70f00c7974240cab8f6ee088aedaa9af2697153ab7805"},
+    {file = "jiter-0.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3b21b412b899fd8bd51a3046934b59a3bb068b79f70a5c6010053ac77cc53f0c"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0758ab7747a984797cf048e8eedea1d8ef39d7994b25611daf5b48fc903e8873"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9ec553a99b0987efd7a3645a1a825cf29c224e494db267a83369fcc8da9aeda5"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3bd327cdfa118bc1ce69c214c2678571d5bd39b8ccd0ebf43a54db00541ba9a"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26d122613ada2b708eb714695446f40fce5bdf2edb4b02116dec62faa62dfab3"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e03a5f21a5ce96a9441b8cb32719a8b88ed5388f53e0f339c5bcf54f1317f9d0"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:a5c54ef4ff776d9675837ef535b3308d6e31c208d43ebc44a0f7ab8a208c68f7"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b1e7923093a376d93c6eb507c77045ae258d689ba577392846a1b3f10d0b09a9"},
+    {file = "jiter-0.16.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2a0d46ef67cc58d906a6132dd3040ca70ae4f0b0d7c9c052fe432c658a69b3f6"},
+    {file = "jiter-0.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:70a490b55634dc0d2606ce8a8e01b1d62459011beb368d15d76e1eaf62460e3d"},
+    {file = "jiter-0.16.0-cp39-cp39-win32.whl", hash = "sha256:9acf1b2faec82d998811ecce7ae84d9005e53410773e9d37d61cdc424ba4581b"},
+    {file = "jiter-0.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:491e7d072a253b156fff46b78bceac4652a697aa8d7082c9c18c03d7b7917d24"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2"},
+    {file = "jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c"},
 ]
 
 [[package]]
@@ -1330,103 +1310,105 @@ regex = ["regex"]
 
 [[package]]
 name = "librt"
-version = "0.11.0"
+version = "0.13.0"
 description = "Mypyc runtime library"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
-    {file = "librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6e94ebfcfa2d5e9926d6c3b9aa4617ffc42a845b4321fb84021b872358c82a0f"},
-    {file = "librt-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ae627397a2f351560440d872d6f7c8dbb4072e57868e7b2fc5b8b430fe489d45"},
-    {file = "librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc329359321b67d24efdf4bc69012b0597001649544db662c001db5a0184794c"},
-    {file = "librt-0.11.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:7e82e642ab0f7608ce2fe53d76ca2280a9ee33a1b06556142c7c6fe80a86fc33"},
-    {file = "librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88145c15c67731d54283d135b03244028c750cc9edc334a96a4f5950ebdb2884"},
-    {file = "librt-0.11.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d36a51b3d93320b686588e27123f4995804dbf1bce81df78c02fc3c6eea9280"},
-    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d00f3ac06a2a8b246327f11e186a53a100a4d5c7ed52346367e5ec751d51586c"},
-    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:461bbceede621f1ffb8839755f8663e886087ee7af16294cab7fb4d782c62eeb"},
-    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0cad8a4d6a8ff03c9b76f9414caccd78e7cfbc8a2e12fa334d8e1d9932753783"},
-    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f37aa505b3cf60701562eddb32df74b12a9e380c207fd8b06dd157a943ac7ea0"},
-    {file = "librt-0.11.0-cp310-cp310-win32.whl", hash = "sha256:94663a21534637f0e787ec2a2a756022df6e5b7b2335a5cdd7d8e33d68a2af89"},
-    {file = "librt-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:dec7db73758c2b54953fd8b7fe348c45188fe26b39ee18446196edd08453a5d4"},
-    {file = "librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29"},
-    {file = "librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9"},
-    {file = "librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5"},
-    {file = "librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b"},
-    {file = "librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89"},
-    {file = "librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc"},
-    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5"},
-    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7"},
-    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d"},
-    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412"},
-    {file = "librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d"},
-    {file = "librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73"},
-    {file = "librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c"},
-    {file = "librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46"},
-    {file = "librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3"},
-    {file = "librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67"},
-    {file = "librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a"},
-    {file = "librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a"},
-    {file = "librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f"},
-    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b"},
-    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766"},
-    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d"},
-    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8"},
-    {file = "librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a"},
-    {file = "librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9"},
-    {file = "librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c"},
-    {file = "librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894"},
-    {file = "librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c"},
-    {file = "librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea"},
-    {file = "librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230"},
-    {file = "librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2"},
-    {file = "librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3"},
-    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21"},
-    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930"},
-    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be"},
-    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e"},
-    {file = "librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e"},
-    {file = "librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47"},
-    {file = "librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44"},
-    {file = "librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd"},
-    {file = "librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4"},
-    {file = "librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8"},
-    {file = "librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b"},
-    {file = "librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175"},
-    {file = "librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03"},
-    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c"},
-    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3"},
-    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96"},
-    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe"},
-    {file = "librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f"},
-    {file = "librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7"},
-    {file = "librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1"},
-    {file = "librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72"},
-    {file = "librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa"},
-    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548"},
-    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2"},
-    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f"},
-    {file = "librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51"},
-    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2"},
-    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085"},
-    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3"},
-    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd"},
-    {file = "librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8"},
-    {file = "librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c"},
-    {file = "librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253"},
-    {file = "librt-0.11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6bd72d903911d995ab666dbd1871f8b1e80925a699af8063fbf50053329fb05f"},
-    {file = "librt-0.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ef69ac715f3cd8e5cd252cb2aebfa72c015492aacc339d5d7bf8fef3c62c677"},
-    {file = "librt-0.11.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:624a40c4a4ad7773315c287276cd024509b2c66ff5904f504bfc08d2c70293ab"},
-    {file = "librt-0.11.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:41dc19fe150b69716c8ece4f76773a9e8813fe3e35e032a58b4d46423fb8d7c0"},
-    {file = "librt-0.11.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4e8bd98ea9c47ae90b319a087ab28dac493f1ffbc1ecd1f28fcdbf3b7e1108d1"},
-    {file = "librt-0.11.0-cp39-cp39-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84308fc49423ce6475d1c5d1985cd69a8ca9f0325fc7d5f81bb690a3f3625d4e"},
-    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ff0fbaf5f44a21beeb0110f2ab64f45135a9536a834b79c0d1ef018f2786bbfa"},
-    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9c028a9442a18e266955d364ce42259136e79a7ba14d773e0d778d5f70cd56f1"},
-    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:9f1692105a02bcf853f355032a5fdc5494358ef83d8fd22d16de375c85cec3f5"},
-    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7a80a71e1fda83cc752a9141e87aae7fef279538597564d670e9ce513f286192"},
-    {file = "librt-0.11.0-cp39-cp39-win32.whl", hash = "sha256:140695816ddf3c86eb972981a26f35efd871c44b0c3aed44c8cd01749386617f"},
-    {file = "librt-0.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:92f7ff819c197fc30473190a12c2856f325ac90aabfccbeb2072d28cc2e234e3"},
-    {file = "librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1"},
+    {file = "librt-0.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34e47058fcc69a313293d6dee94216a4f30c929ae6f2476e58c5ba635aa639d5"},
+    {file = "librt-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dbdd5b6509d0c2a8fe72cf494c299a61dbd58142a90a4190664ae159e4a7b547"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e56ea4ee4df77585a6b5c138f6538680886024fa559f5b55bd14b12e98e67b2"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f1f9cc4d09a46d9cb3c2063ae100629d3f52a6517c3c08c2f4c9828261883929"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f125f5d46b20f89dc5587a55cc416b4ba2a5b2ffda36d048ee120e17598a653a"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2608d3b39f9e0b4a66a130d9150c615cba40a5090d25eeeaa225e0e46de8c0ac"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9fd35e95ab5e45c3901d37110263c7db85a961110f5460588fe37f8c131f88a7"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5f31b0aa13c9b04370d4da6be1ab7779776b3a075cceb6747a39a4be85fe1e40"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0b795f5fc70fbbb787ceaf79bb3a0d627bcc33c53de51741755263ec406b775a"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36b306a623aaad96fe4b378692b54f9c0789fccd833b9851753d5fbf6138cfde"},
+    {file = "librt-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a3762e75fcac8c9e4dacaaf438bffd9003e2ca2c531b756f3c0035deefa674c8"},
+    {file = "librt-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:d63bae12a8aeb51380be3438e4dc4bd27354d0f8e19166b2f44e3e94d6f552dc"},
+    {file = "librt-0.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1b5a7bbff495baedbd9b916c367d66854008f8f3b575908ded477c499dc60082"},
+    {file = "librt-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34bc7938b9fdf14fe32a406c19c71faf894c5cee7e7474bd0be2f17200b82d14"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f40e56b61b41be5f7dec938cfeffd660668cf4b5e72c78e7bd671d66b7bc2c79"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:9c5d02b89de5acd0379a51ec44a89476fb03df6145442e1c8ecd6bee2f91b176"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7db9a3ff32ef5f7d1703d93831a3316cdf0b537de6a1cc03cc8fdd09b9194e89"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3dbb2a31882456cadc7053378e81ad7ed7693db4ac9f98ab5f81ef034aa8ec9f"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c6014e3c80f9c1fe268ef8b0e0ef113bac672cc032f2f93866e7ddad4f3e663d"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:091b60a4d2174fc1ec5c34cdc0b72efb6224753d76b7da61ebeab7a191aec8bd"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:66cb1138f384a191a6d75f986064841fcfdc0cea98f7bd9c9ab9b38049917588"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:17221a7569f8f292aa0014226e48aa25b8c2b08da18088cd230953d0ea0f9cd1"},
+    {file = "librt-0.13.0-cp311-cp311-win32.whl", hash = "sha256:fc67741da44c6eaa90e01eafb586bbba9b51eb5b6ed381ee6f5ae72eb3316d21"},
+    {file = "librt-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc99dfb62b23c9207c33d0be8a2e2af7a42e21e6ea388b380a0c948c7b88953b"},
+    {file = "librt-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:40ccd13c252d3fe473ffc8a57be7565abc8b64cf1b108344c859d5164f7f3e0c"},
+    {file = "librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0"},
+    {file = "librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82"},
+    {file = "librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3"},
+    {file = "librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa"},
+    {file = "librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1"},
+    {file = "librt-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a468951af16155824e88bdd8326ebe5bdb371f3ec0ac04642994b98201d914f3"},
+    {file = "librt-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae01d8512cc17079e53425635327dbf3f7ff57a42c00dec348bf79791c56444c"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32c26893cd085c1efe83219e78d866da23fb20a066101b8f68210004361d224c"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5929da1981a46bcf4b28b1b9499905f0ff58e2419da402a048234e9783acbc4b"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94b85d664d777bab6c0d709416cb42938251fda9e221b79e3a2215d85df5f4f9"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:531b2df3e9fe96b1fcf73a6d165921e4656be5f58d631d384ebce344298368db"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:109b84a9edf69ad89dc1f66358659e14a031baca95e3e5b0060bd903ede8efd6"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1304368a3e7ffc3e9db986796cc5326fdb5943a3567ecc137cff318e4240c0e7"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e4f9b472e7d308d94b62c801982065661158c6ed02790d6c7ddb4337cea0f9c1"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f836c37478f167a81200d8c8b2c920a22224564bed2c23d7aeec760965c367a"},
+    {file = "librt-0.13.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:4000d961ff9598ac6ea603c6c836a5ed49bc205ade5fc378b998dfe1e2c36628"},
+    {file = "librt-0.13.0-cp313-cp313-win32.whl", hash = "sha256:79e44cff71750d299d61a678e49995b0d5935a9cda238c2574daeca3ba536927"},
+    {file = "librt-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:54dab44a847d5ad1acd05c8a83fe518ae685516ecf4d3f7cc6e3df2a66767650"},
+    {file = "librt-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:d4cb6fbfdf874340ab5e51450753c0f817b6958a3621125ee695bbc3de866566"},
+    {file = "librt-0.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:25218d94b1d2cbc0ba1d8a3f9dc9af578d9646e5ed16443a70cde1dfdcce6d71"},
+    {file = "librt-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f26629539d4893c2957a16c41bb058e1e135c1f150f6a2e25ed047f64cf3f5c6"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4517d47b2b8af26975a406fba7d314de9696d864252e0257c6ea90238cfe27f"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f19e181de5b3a1148bb3420b8c4b0b0ea0fce6950099724ad151d6cea5acc180"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22034924f5b42d5a56371cf271771bfeaabf235a7a8b6264bef2d20013f786c6"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7897db4e95e22468bdda33d8e012ceacd0182abf001e6389d763f0def6286b9"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ce61b3746545029d4f5c17d6bd74b676254ad98433086c846ffb5e8fa73f007"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:46c330e82565962c761dbce7941be2cff7db674ee807455a8d0cadc5f9b759b0"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:375f5af8f99cbaa99dd293af986e3d57caabc9ba81a5d3f021603764854197a1"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9320d34c3376ae204b2cd176e8d4883a013934e0aef822f1aed9c536490c275d"},
+    {file = "librt-0.13.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:9af313c66157a69dc69ea0059a66961692250e0dc95af9c385a48ffb770a0d16"},
+    {file = "librt-0.13.0-cp314-cp314-win32.whl", hash = "sha256:f2a7253458e34f33543551394ae4fe104b497ec2a65ac266074de64c1df82e37"},
+    {file = "librt-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:a3dfe4edf10e8ed7e55b026a8bfc2c2a8704218b659cd4bffdf604fab966dc39"},
+    {file = "librt-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:68a5faee4bba381cb93b5961f684a514cf0053cb92308ff9c792c2fea0b174c6"},
+    {file = "librt-0.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a38fb81d8376dfa2f8963b265fec07637802b0d01e2a127c19c66cb070fb24f5"},
+    {file = "librt-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d4c8d9bd5abce34b2e75edb3bf37ab0f34e49b1f915a40ae8468eb7c85bc5b46"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:387e2f1d27e89bffe0d3f520f0da0662c973fd607ca16c1808f8a5085419485e"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4f6db193d2e5e0ed60359b9a5a682cd67205d0d3b1e459a867dd4b5c4e7eaa7a"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d38604854e8d22faadf683ec6c02bb0f886e2ba56ef981a1c36ee275f21ea22"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:371f7ce73026815dafd51c50ce38416e91428b28c4b2ec97cd39271164b0045c"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3aaedf52171bee90860704c560bc798fe83b76247df47568e0197e9b13c735a0"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:96bad8725a4f196a798366c25ce075d1f7543a4ec045ffc13e6a7ec095cdab04"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6bf6a559ffe4a93bbea6cf31ddf01a7fd9ba342ef51f27beb178e318b74acd61"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:301067672387902c55f94b51d5022304b36c966ea9fe1f21caab99a9bef487c9"},
+    {file = "librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18"},
+    {file = "librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259"},
+    {file = "librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99"},
+    {file = "librt-0.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f442e3954b1addc759faae22a7c9a3f1e16d7d1db3f484279dc27d62e06968fa"},
+    {file = "librt-0.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e786428f291dd2d2f1cbfc0e0caa45a2e395fab0ad3e2c9314daa8873414390"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21b7ac084f701a9cdff6139745a6620579d65a9379ac2d9d50a86368b109e63c"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a6e556d6aba31c93dd97ce661d66614d2429c0a3923f9dc8f0af7e8df10223a4"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3657346f867469e962549435aa05fd15330b1d6a92829f8e27988e194382d005"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:791aa18a373b90da8ac3c44fc77544f33fdf53ae403acdce9b39f1c26b4a3b94"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d6fb0eaa108814581c4d3bfbd068c3fb6757812a81415008d1bae08267cca360"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a001519c315d5db40710f2665d32c4791f1d4779fc96a9423fd18d92c8b9ac7b"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:d9188caac26e47671b52836a5e2a49873a7fc11c673b0c122d22515f98bc14e1"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:05d96b80b95d3a2721b619f8982b8558848b04875bb4772fd54842b59f61dd97"},
+    {file = "librt-0.13.0-cp39-cp39-win32.whl", hash = "sha256:c3cd253cf32fe4f4662960d6bf7d55cb8be0c31a5d644a4d48aeafebaff3409a"},
+    {file = "librt-0.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:b15e26cc0fe622d0c67e98bee6ef6bc8f792e20ee3006aa12627a00463d9399f"},
+    {file = "librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781"},
 ]
 
 [[package]]
@@ -1827,14 +1809,14 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "platformdirs"
-version = "4.10.0"
+version = "4.11.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"},
-    {file = "platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7"},
+    {file = "platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74"},
+    {file = "platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0"},
 ]
 
 [[package]]
@@ -1855,29 +1837,29 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.52"
+version = "3.0.53"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
-    {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
+    {file = "prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2"},
+    {file = "prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6"},
 ]
 
 [package.dependencies]
-wcwidth = "*"
+wcwidth = ">=0.1.4"
 
 [[package]]
 name = "proto-plus"
-version = "1.28.0"
+version = "1.28.2"
 description = "Beautiful, Pythonic protocol buffers"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8"},
-    {file = "proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9"},
+    {file = "proto_plus-1.28.2-py3-none-any.whl", hash = "sha256:b874236fcac2358f601e4330bcb76cb8b89c851303ccf4078408b3d4774d1c52"},
+    {file = "proto_plus-1.28.2.tar.gz", hash = "sha256:26d843eb99c1e32fdf1d20ff0faae56607f7748fe774acf9ecd5cfe6c6472501"},
 ]
 
 [package.dependencies]
@@ -1949,14 +1931,14 @@ dev = ["black (==22.6.0)", "flake8", "mypy", "pytest"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]
@@ -1993,11 +1975,11 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
-markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
+markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", dev = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -2552,14 +2534,14 @@ rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "responses"
-version = "0.26.1"
+version = "0.26.2"
 description = "A utility library for mocking out the `requests` Python library."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345"},
-    {file = "responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2"},
+    {file = "responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364"},
+    {file = "responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8"},
 ]
 
 [package.dependencies]
@@ -2572,14 +2554,14 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "s3transfer"
-version = "0.19.0"
+version = "0.19.2"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262"},
-    {file = "s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685"},
+    {file = "s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25"},
+    {file = "s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993"},
 ]
 
 [package.dependencies]
@@ -2638,18 +2620,18 @@ files = [
 
 [[package]]
 name = "slack-sdk"
-version = "3.42.0"
+version = "3.43.0"
 description = "The Slack API Platform SDK for Python"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "slack_sdk-3.42.0-py2.py3-none-any.whl", hash = "sha256:eb39aff97e476e10cc5a8ac29bd2e79a9959e880d9fe0c03b4e8f05b2ac996ff"},
-    {file = "slack_sdk-3.42.0.tar.gz", hash = "sha256:873db9e1f632ac650ffdbf9d8ba825f3e9e7e576a1e4f9604ccb2a15b3727e3d"},
+    {file = "slack_sdk-3.43.0-py2.py3-none-any.whl", hash = "sha256:4b6557c65577fc172f685af218b811f9f3b4909e24cddd839ada09565f10c585"},
+    {file = "slack_sdk-3.43.0.tar.gz", hash = "sha256:0553152e46c4259eb69f7464cdadc35ba4802ca10f9f5a849c92cf03d6c2ba07"},
 ]
 
 [package.extras]
-optional = ["SQLAlchemy (>=1.4,<3)", "aiodns (>1.0)", "aiohttp (>=3.7.3,<4)", "boto3 (<=2)", "websocket-client (>=1,<2)", "websockets (>=9.1,<16)"]
+optional = ["SQLAlchemy (>=2.0.49,<3)", "aiodns (>1.0)", "aiohttp (>=3.13.5,<4) ; python_version >= \"3.9\"", "aiohttp (>=3.7.3,<3.11) ; python_version == \"3.8\"", "aiohttp (>=3.7.3,<3.9) ; python_version == \"3.7\"", "boto3 (<=2)", "websocket-client (>=1,<2)", "websockets (>=9.1,<16)"]
 
 [[package]]
 name = "sniffio"
@@ -2677,14 +2659,14 @@ files = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.4"
+version = "2.9.1"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"},
-    {file = "soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e"},
+    {file = "soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c"},
+    {file = "soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba"},
 ]
 
 [[package]]
@@ -2844,14 +2826,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "tqdm"
-version = "4.68.3"
+version = "4.70.0"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03"},
-    {file = "tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482"},
+    {file = "tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953"},
+    {file = "tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220"},
 ]
 
 [package.dependencies]
@@ -2865,30 +2847,30 @@ telegram = ["envwrap", "requests"]
 
 [[package]]
 name = "traitlets"
-version = "5.15.1"
+version = "5.16.1"
 description = "Traitlets Python configuration system"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92"},
-    {file = "traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722"},
+    {file = "traitlets-5.16.1-py3-none-any.whl", hash = "sha256:f775618166caa0396c8e337099240f2bd3e5e917d203b2e6fbe21a58d3cb1f6b"},
+    {file = "traitlets-5.16.1.tar.gz", hash = "sha256:ed900c2b631aa3a112811139fa97b8d2c3bad5e989656bba4b7e52c7852c18c1"},
 ]
 
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
-test = ["argcomplete (>=3.0.3)", "mypy (>=1.17.0,<1.19)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
+test = ["argcomplete (>=3.0.3) ; python_version < \"3.12\"", "argcomplete (>=3.5.2) ; python_version >= \"3.12\"", "mypy (>=2.0) ; implementation_name != \"pypy\"", "pre-commit", "pytest (>=7.0,<10.0)", "pytest-mock", "pytest-mypy-testing ; implementation_name != \"pypy\""]
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
-    {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+    {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
+    {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},
 ]
 
 [[package]]
@@ -2926,14 +2908,14 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "wcwidth"
-version = "0.8.1"
+version = "0.8.2"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8"},
-    {file = "wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9"},
+    {file = "wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85"},
+    {file = "wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda"},
 ]
 
 [[package]]
@@ -2974,102 +2956,102 @@ test = ["pytest (>=6.0.0)", "setuptools (>=77)"]
 
 [[package]]
 name = "wrapt"
-version = "2.2.2"
+version = "2.3.0"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "wrapt-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:055e6fcfaa28e58c6a8c247d48b92be9d56f818b7068aa4f22b15b3343a09931"},
-    {file = "wrapt-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8374eb6b1a58809211e84ff835a182bb17ab2807a5bfef23204c8cff38178a00"},
-    {file = "wrapt-2.2.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:656593bb3f5529f03d27af4136c4d7b11990e470bcbc6fefa5ef218695bece55"},
-    {file = "wrapt-2.2.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb00cb7bb22099e2f64b7340fb96113639aa7260c0972af3797ace2297b936c"},
-    {file = "wrapt-2.2.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7f10ee0bd53673bfd52b67cbce83336fe6cad90d2377b03baf66491d2bbfb91"},
-    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4402f57c5f0d0579599858ffbdd9bf4e3f0972f51096f2bd6cc7dab6b76ee49e"},
-    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3a4eb7964ff4643d333c84f880bcf554652b2a1050aebc54ae696327f61acfaf"},
-    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e542b7c5af91e2123a8aabf19894319d5ec4268d2a9ffd2f239386133fc47746"},
-    {file = "wrapt-2.2.2-cp310-cp310-win32.whl", hash = "sha256:6e7e45b43d3c774d244fe7264378f5a3f0f383bc55a54a9866434e524540110f"},
-    {file = "wrapt-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:955f1d6e72a352e478de8d8b503abe301c5e139a141b62eb0923bd694995025f"},
-    {file = "wrapt-2.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:b89d8d73c82db2bb7e6090b3afd7973f980d24e905cc34394eab60b884b3bf67"},
-    {file = "wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73"},
-    {file = "wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e"},
-    {file = "wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d"},
-    {file = "wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328"},
-    {file = "wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5"},
-    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0"},
-    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae"},
-    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099"},
-    {file = "wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c"},
-    {file = "wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971"},
-    {file = "wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30"},
-    {file = "wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b"},
-    {file = "wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb"},
-    {file = "wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a"},
-    {file = "wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900"},
-    {file = "wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79"},
-    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a"},
-    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf"},
-    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab"},
-    {file = "wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da"},
-    {file = "wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f"},
-    {file = "wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8"},
-    {file = "wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69"},
-    {file = "wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617"},
-    {file = "wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e"},
-    {file = "wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d"},
-    {file = "wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b"},
-    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c"},
-    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f"},
-    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94"},
-    {file = "wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d"},
-    {file = "wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4"},
-    {file = "wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac"},
-    {file = "wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5"},
-    {file = "wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec"},
-    {file = "wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9"},
-    {file = "wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c"},
-    {file = "wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194"},
-    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066"},
-    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20"},
-    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af"},
-    {file = "wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9"},
-    {file = "wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28"},
-    {file = "wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0"},
-    {file = "wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745"},
-    {file = "wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00"},
-    {file = "wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc"},
-    {file = "wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95"},
-    {file = "wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33"},
-    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab"},
-    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663"},
-    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d"},
-    {file = "wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56"},
-    {file = "wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406"},
-    {file = "wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c"},
-    {file = "wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a"},
-    {file = "wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063"},
-    {file = "wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f"},
-    {file = "wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81"},
-    {file = "wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c"},
-    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff"},
-    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5"},
-    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c"},
-    {file = "wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca"},
-    {file = "wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77"},
-    {file = "wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347"},
-    {file = "wrapt-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d01d8e0afc55823245a3b97a79c7c77464e31ea7a7b629a4bf26f9441dc1f18e"},
-    {file = "wrapt-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a28287413351cb198b8c5ddd045c56fac1d195808642cd264d1ab50426146650"},
-    {file = "wrapt-2.2.2-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:abf033b7e4542357659cd83ed6cd5033c43aaa1887044045ceb571528837f72f"},
-    {file = "wrapt-2.2.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d2f6573561fa05002e5ee71529f4ab0a7dffed3e45b51013fe6298fe2723c02"},
-    {file = "wrapt-2.2.2-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c38510a21d5b9cf3e84c460d909e9f2a098667439fd42841bb081cab45835d68"},
-    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:cd385a48b055bdc3630ab30e0c7fd8514a36904ec23f9cee7a65d887334a3cea"},
-    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:3dc3dcfc2da95d501905f10dc11a0dc622e91d8cdd8bbfcb63ca54afd131e556"},
-    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:fa81c5b5fe8cd6c41e3a798533b81288279e5fdbde2128f21071922764281c99"},
-    {file = "wrapt-2.2.2-cp39-cp39-win32.whl", hash = "sha256:814f1bf3e0a7035f67a1db0cdaf5e2bbcaa4d7092db96673cfa467adeaab8591"},
-    {file = "wrapt-2.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:9ee098171b07edba66ab69a9bf0251d3cbef654107e800feb24c0c6f30592728"},
-    {file = "wrapt-2.2.2-cp39-cp39-win_arm64.whl", hash = "sha256:3179a4db066b53d40562e368b12895440c8f0953b6543b89d6acc41c0273996e"},
-    {file = "wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048"},
-    {file = "wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302"},
+    {file = "wrapt-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0bb2797048db0956348cb3058c33bc4184614f13231389cfbccc16a5d32780a7"},
+    {file = "wrapt-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ce9f398f868d2b3b27aa2ea4de79645ef9077aeeac8dfc2814b0d542c6a2b87f"},
+    {file = "wrapt-2.3.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ad71df7a04dd3497e9302e81f4a7c91bd401ea0e15a9df9029527900f94bee43"},
+    {file = "wrapt-2.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc82c2ccc8e234c844f5303d9f2984b346dcdd53e94823ce8420d2c75b4b9023"},
+    {file = "wrapt-2.3.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a6e19531ae33c508cea7d84a7edfda01fa86e51b8d1a93a77712c55e6e469152"},
+    {file = "wrapt-2.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:df4ce31150bcd5d9f36f816aac3010ab4f4bf8672ac1d3b0ac7d539ec61c7c02"},
+    {file = "wrapt-2.3.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:e2e692bc0d63f881cf7006730a56bd4e0c2fab5dc318466942805d692b166276"},
+    {file = "wrapt-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c8388ba7faf5dbf9ee106bb70d66f257629b1bd98091123e19e8a4553a319199"},
+    {file = "wrapt-2.3.0-cp310-cp310-win32.whl", hash = "sha256:e045ff75d7d94900fc32896ed93c45ce2d2cac28c9dead582ff9a5a49d446e35"},
+    {file = "wrapt-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:b4fc96b159af0a3e0faa72475a69d66292bea72a5bed1e1aca1bffbddc3cb2b0"},
+    {file = "wrapt-2.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:1236fa25173ca964c97422470482e9011b9e3c7ed0d75798b40b3da3b0e0e760"},
+    {file = "wrapt-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5ab559e1b2551d23d54db2a0001c6d73bad022a254639561c5f6c382a9d6c2fe"},
+    {file = "wrapt-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bff9a671bc00709cab5a7f745c592b5671873449db0ee2a569af994f16b29a4d"},
+    {file = "wrapt-2.3.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fc648a335d7e01adb3640b25f02fd0ea05886cf04d0af7f4ee902bc7b5e466e8"},
+    {file = "wrapt-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d0077f3d65541925fa83002f967b22ad6550d24813ac64cb905f717194128d9c"},
+    {file = "wrapt-2.3.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9790ea25190a4e0fe4cdf4eeb868e9d75f8a024a70a5b6bf9c348a3a2b72e731"},
+    {file = "wrapt-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:816877aa749253149f9ecfd2635d4d948ecfa338e1a0311d187b1acb1bb8a3eb"},
+    {file = "wrapt-2.3.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d1c2c1b808600d2ea808e6360910a60ed5f409a4011655e10f9164ba0a414a6"},
+    {file = "wrapt-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5ba1e5e08ddc46130e9682b2c249f2d1dd39bda9106ed4bd401b7519f18f41bd"},
+    {file = "wrapt-2.3.0-cp311-cp311-win32.whl", hash = "sha256:45c9279b373d15649dfa2c2077cb3408ea1a6d3125afbdab9d6b809a66f68e14"},
+    {file = "wrapt-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:195b1842b4122fb54e3cd3dd5b2b4aa49302a5a61da901df0481f5c97aedde84"},
+    {file = "wrapt-2.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:6db604ef0c67bdb2042ecdfd7b7f037cf09733557ca42360d1018285634f7b98"},
+    {file = "wrapt-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a45ffae742ce91a16e11cb6c7cd71e7f9994f3cbd283b962ab093f5c6dcf525"},
+    {file = "wrapt-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69e477046f2237ef0bc6547544ee73008dc764ca26eff44f09e976d221b34d5d"},
+    {file = "wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d221a6e6ddd302b8397433184e96b59f259f50024b854db1c411a881586b6b8"},
+    {file = "wrapt-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:392158c9a7f2ab1b8699418bfc0fe6f83548788c418b27d7bf2019ad3405cebb"},
+    {file = "wrapt-2.3.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e5301c35cf75655eb33498f2bd6ae8703ca19940e3167dc9cdf740c712a39c60"},
+    {file = "wrapt-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:418f54bb09d1762db02c7009b4051149893af3153a87f92d70356703c11eea02"},
+    {file = "wrapt-2.3.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1598becd30f8f2777d18564064eb4f4dbe1ab0e05a8f09786d0ef505ac782bf3"},
+    {file = "wrapt-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3da470536bf9645143323dd41b32db55c6f4304ad382094c1a1da8a92061e10d"},
+    {file = "wrapt-2.3.0-cp312-cp312-win32.whl", hash = "sha256:fb8e2e6704a1e0b1b989546c69e2688371ef4a07fa5f61bde3eb6211186f5ac1"},
+    {file = "wrapt-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:cdc021cb0b62471d6aac7f2bd92f3b4658073775f9ee7fcd325c511129e7bcc8"},
+    {file = "wrapt-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:67bfe2485f50368c3fcd2275fc1fd100e350d601e0058921a7c82678a465aeab"},
+    {file = "wrapt-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d3fb71e65b001adfc42684522eeccd9c21d8ba679945abc993439567b66e59f"},
+    {file = "wrapt-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:51a7a4181c1295774812271fbcd7c909df372bc25579d4ed9eb875caaf0ae86f"},
+    {file = "wrapt-2.3.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9045917809c63fdf7abe3a2ceaed3d670b8ee4500ddd9291192d30aeb34467c5"},
+    {file = "wrapt-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54ca1d5573f69b5fe1d74f1f65799c68015e82f685efec9fd8cfa40a094c44d0"},
+    {file = "wrapt-2.3.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:242b60c21e30866e6a2fa606c612b47c553fa60c0eaeeeb7797fb842ac0ce609"},
+    {file = "wrapt-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3f3d7ec0a51fbfe00d3aef047641ff2c58b25565b4717fc1f90e050be01cba8"},
+    {file = "wrapt-2.3.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:261f53870cd4fb2bf38f9f972c56c728fd224cb7c65721307de59d9e7e6741ae"},
+    {file = "wrapt-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8159ec0b0cb7608175eb150de94c19e34f4d47ac655f5ca9baf45df6b688ffd3"},
+    {file = "wrapt-2.3.0-cp313-cp313-win32.whl", hash = "sha256:10461884b3014fbfc8eb7d09a93c5f246363e6711d9d881f95eb8c27fdef049f"},
+    {file = "wrapt-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac870cc97b73bb00ac353329e9559a4bebc47c4c86792ed9b23b58c15b6ad838"},
+    {file = "wrapt-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:a65e8db2b4e90c2e7ade931086351c98ef420bf7a94ee08c95ac8a3cbbc43579"},
+    {file = "wrapt-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:fd1f2f557dd3491fe75905e578f4db967393d40d1a8f468edc4d40ac7f2d5944"},
+    {file = "wrapt-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9f5d2aec29dfc76c37e23897dee92766a3fd4f3bff3ae7fc9c6b4bf37d8c1360"},
+    {file = "wrapt-2.3.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:646d20d413ffcd1b0a2f700076e2d0252d872dcb7754860a73e45a59ea883614"},
+    {file = "wrapt-2.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:379f670f45b7bb8993edd9f6fc36c6cc65edb81cffa0b504be34acb0303fff0a"},
+    {file = "wrapt-2.3.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6208f302f110295d64b22a7ac96500c791bf492dce4366e622e4912b077c9687"},
+    {file = "wrapt-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ed635a9ca4f3a5a2b900c10c69e823373bc00ebc114b459383596d3487da3570"},
+    {file = "wrapt-2.3.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e3b9eaa742ae7a0aaaaad4ca4b69469d757af2d6e6663ef1dadc47adec0aeb41"},
+    {file = "wrapt-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d0f7284f88f4833705132d06d3b425a43095c2cbd07c58166aac3ab646ba12a4"},
+    {file = "wrapt-2.3.0-cp313-cp313t-win32.whl", hash = "sha256:7ebb274aba688b043429eb1500ff8a76ce0cb8ac0812ca3e301f06247b8722b3"},
+    {file = "wrapt-2.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c4bded758ad6f03b965830944a2f0bc5b2eb3767fe5a7310134315d1a6610e98"},
+    {file = "wrapt-2.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:d2cc64539da63e39ffb9c7ede849b6e8ddaaf7b3876b5cfb04efd85a5f3f4eb6"},
+    {file = "wrapt-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea52a0d0f08c584943d5764be0e84efa912c8da23c23e1e285ff2f5641c18fcc"},
+    {file = "wrapt-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd85b0aa88efdb189d6ae2f35f4526943a8f091c38599c9c31478241c819e6a1"},
+    {file = "wrapt-2.3.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:141ed6211286a9660d8d6702de598b43f0934b4f0eda16393f100a80f501d945"},
+    {file = "wrapt-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e49885a62ec4ee854d1b9e6371fda6afd219917225752abf729a3f36d4df9a5"},
+    {file = "wrapt-2.3.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d6159c9b2fefec02314e1332dbbbfaf960e369dfd26bcf7f8b258b5732065b3"},
+    {file = "wrapt-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24da48596326ef8e448cfa837b454f638713d3531262375f00e5a9681682fc07"},
+    {file = "wrapt-2.3.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cd3a2edf0427013736b8127955cec62608c56e53ea47e82812ea32059cda407f"},
+    {file = "wrapt-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fa0df3bff4e7ce45759f33fd39335fe2f60477bb9ecf7b8aa41e7d07ee36a23"},
+    {file = "wrapt-2.3.0-cp314-cp314-win32.whl", hash = "sha256:2935d5454b3f179a29b12cf390ee47246740ba2c3a7545b1b46ba31a5f2a4a0b"},
+    {file = "wrapt-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:cc2cea812e5cb179a796b766747e7d3b21088760d8deb95676d482b8c8e6fa7d"},
+    {file = "wrapt-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:22cc5c0a717bd4da87018ae0bffd4c19c6fb679d3ff357216ba566ab26c76cab"},
+    {file = "wrapt-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a6b5984cd65dd639546f0eb4b8eacf1c31cb2fe9fb5c27bffe240987cdb2cf84"},
+    {file = "wrapt-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c88abcf53daef80e01a75c7530e727fa6e2c1888fe83e3dcdba4c96216a1f5c7"},
+    {file = "wrapt-2.3.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:85de890ff968196e92dd1ae73a9fb8970495e7650a457b1c9ef0ac3dd550bce2"},
+    {file = "wrapt-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50f416b74d092bb9f41b424e90dd457f365f7ba4b11de62a23679769a21bd85c"},
+    {file = "wrapt-2.3.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39febbee6d77301d31da6996b152ce52452da7c7ef72aba10c2fa976dff9c295"},
+    {file = "wrapt-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:93513bec052c6cd987f9f580c3df068c8bc4ebae6543736be3ca7ec5959cafcd"},
+    {file = "wrapt-2.3.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:729126e667da34d251b8ebf8a45ef0c5ddadc21542b3d6e1abf4259ece6508df"},
+    {file = "wrapt-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:626b69db2021aa01671ec7bbc9740e558522bd44c18cf2ce69bf3d666a014109"},
+    {file = "wrapt-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:629d73378082c00a8173031f9fb30a3ac6abbc894a5bfdfae71fabc60642d501"},
+    {file = "wrapt-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:42869085687f0aefd57c0f636c3f9354f8ffb321a8ba9cb52d19beb796e561c5"},
+    {file = "wrapt-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b1e5aa486e269b00ed35e64771c7d0ab8096cfd2643405ca8cd60ebedc099a51"},
+    {file = "wrapt-2.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c3b476ae63b4a3b4da681aafcb25ff3542d289fbda8b5da7caf76aaffafafdbb"},
+    {file = "wrapt-2.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:932dced0a7b2950ed58a3325536a1dcb7b58e7330af54e8552d2e566b5328b99"},
+    {file = "wrapt-2.3.0-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0db083387d6e75ec0be8173ecbf0e811cf60bae1cc75a815feb104167ea10d4d"},
+    {file = "wrapt-2.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abc71504669d126d91f89fc0e388c6295d8fbd2439be884f175133fda8aa403c"},
+    {file = "wrapt-2.3.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b767a9566f165dd14decf8f4194c6bb0ce3a8420cec213824e05a99400c9260a"},
+    {file = "wrapt-2.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:73d0b10b64620a2cf4bc3d31775c4d9527e309a5549e4379e3bf71e8d2dc193e"},
+    {file = "wrapt-2.3.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:e31734c5077f29f892b2565eee5106d610278151ad49fc6a9d69a647cd5730e2"},
+    {file = "wrapt-2.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:628f3ba8ec793a5b10a6cd8c6c6b7b55eb552abd1f3bd301336acb74c7a82dfe"},
+    {file = "wrapt-2.3.0-cp39-cp39-win32.whl", hash = "sha256:3873c3c5ca9f4ef91f693602eca19d1f1e7c410338df82a4ff11d826b5896a8f"},
+    {file = "wrapt-2.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:8f8a1c6472675956cece9a8f403f43c3594f1681319eed2dd56f60877397c636"},
+    {file = "wrapt-2.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:c8858d8ff9822a081e3cc49ae1b3b22f0f789c14001cdac8f94564010d9c9d66"},
+    {file = "wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2"},
+    {file = "wrapt-2.3.0.tar.gz", hash = "sha256:681a2d0eefd721998f90642762b8e75c2159ec531b20ad5e437245ea7b06a107"},
 ]
 
 [package.extras]

--- a/tests/authenticators/test_auth_aws.py
+++ b/tests/authenticators/test_auth_aws.py
@@ -312,7 +312,7 @@ class TestGetInitSessionArgs:
         assert _get_init_session_args(auth_config) == expected
 
     def test_with_all_parameters(self):
-        """Test with all parameters provided."""
+        """Explicit credentials win; the profile is dropped rather than combined."""
         auth_config = AWSAuthenticatorConfig(
             aws_profile="test_profile",
             aws_access_key_id="test_id",
@@ -321,10 +321,22 @@ class TestGetInitSessionArgs:
             aws_region="us-east-1",
         )
         expected = {
-            "profile_name": "test_profile",
             "aws_access_key_id": "test_id",
             "aws_secret_access_key": "test_secret",
             "aws_session_token": "test_token",
+        }
+        assert _get_init_session_args(auth_config) == expected
+
+    def test_profile_kept_with_partial_credentials(self):
+        """A key id without a secret is not a usable credential, so the profile stands."""
+        auth_config = AWSAuthenticatorConfig(
+            aws_profile="test_profile",
+            aws_access_key_id="test_id",
+            aws_region="us-east-1",
+        )
+        expected = {
+            "profile_name": "test_profile",
+            "aws_access_key_id": "test_id",
         }
         assert _get_init_session_args(auth_config) == expected
 

--- a/tests/backends/test_backends_s3.py
+++ b/tests/backends/test_backends_s3.py
@@ -66,6 +66,81 @@ class TestS3BackendInit:
         ):
             S3Backend(mock_authenticators, "test-deployment")
 
+    @pytest.mark.parametrize(
+        "error_factory,error_args",
+        [
+            (
+                botocore.exceptions.TokenRetrievalError,
+                {"provider": "sso", "error_msg": "Token has expired"},
+            ),
+            (botocore.exceptions.NoCredentialsError, {}),
+            (
+                botocore.exceptions.PartialCredentialsError,
+                {"provider": "test", "cred_var": "AWS_SECRET_ACCESS_KEY"},
+            ),
+        ],
+        ids=["token_retrieval", "no_credentials", "partial_credentials"],
+    )
+    @mock_aws
+    def test_init_auth_errors(
+        self, mock_authenticators, mocker, error_factory, error_args
+    ):
+        """Test that various auth errors raise helpful BackendError."""
+        error = error_factory(**error_args)
+        mocker.patch.object(S3Backend, "_check_table_exists", side_effect=error)
+
+        with pytest.raises(
+            BackendError, match="AWS authentication failed:"
+        ) as exc_info:
+            S3Backend(mock_authenticators, "test-deployment")
+
+        assert exc_info.value.__cause__ is error
+
+    @pytest.mark.parametrize(
+        "error_code",
+        [
+            "ExpiredToken",
+            "InvalidClientTokenId",
+            "SignatureDoesNotMatch",
+            "AccessDenied",
+        ],
+        ids=["expired_token", "invalid_token", "bad_signature", "access_denied"],
+    )
+    @mock_aws
+    def test_init_client_error_auth_codes(
+        self, mock_authenticators, mocker, error_code
+    ):
+        """Test that ClientError with auth codes raises helpful BackendError."""
+        client_error = botocore.exceptions.ClientError(
+            {"Error": {"Code": error_code, "Message": "Auth error"}},
+            "DescribeTable",
+        )
+        mocker.patch.object(S3Backend, "_check_table_exists", side_effect=client_error)
+
+        with pytest.raises(
+            BackendError, match="AWS authentication failed:"
+        ) as exc_info:
+            S3Backend(mock_authenticators, "test-deployment")
+
+        assert exc_info.value.__cause__ is client_error
+
+    @mock_aws
+    def test_init_non_auth_client_error(self, mock_authenticators, mocker):
+        """Test that non-auth ClientError is re-raised."""
+        client_error = botocore.exceptions.ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
+            "DescribeTable",
+        )
+        mocker.patch.object(
+            S3Backend,
+            "_check_table_exists",
+            side_effect=client_error,
+        )
+
+        # Should re-raise the original ClientError, not BackendError
+        with pytest.raises(botocore.exceptions.ClientError):
+            S3Backend(mock_authenticators, "test-deployment")
+
 
 class TestS3BackendCheckBucketExists:
 

--- a/tests/definitions/test_definitions_prepare_extra.py
+++ b/tests/definitions/test_definitions_prepare_extra.py
@@ -123,7 +123,9 @@ def test_vars_typer_complex():
 
 
 def test_create_local_vars(mocker, def_prepare, definition):
-    mocker.patch.object(Definition, "get_remote_vars", return_value={"foo": "bar"})
+    mocker.patch.object(
+        Definition, "get_remote_vars", return_value={"foo": "bar.outputs.baz"}
+    )
     def_prepare.create_local_vars("def1")
     outfile = (
         Path(definition.get_target_path(def_prepare._app_state.working_dir))
@@ -131,7 +133,7 @@ def test_create_local_vars(mocker, def_prepare, definition):
     )
     assert (
         outfile.read_text()
-        == "locals {\n  foo = data.terraform_remote_state.bar\n}\n\n"
+        == "locals {\n  foo = data.terraform_remote_state.bar.outputs.baz\n}\n\n"
     )
 
 
@@ -233,15 +235,17 @@ def test_get_provider_content(def_prepare, mocker, definition):
 
 
 def test_get_remotes(def_prepare, mocker, definition):
-    definition.remote_vars = {"a": "one.var", "b": "two.var"}
+    definition.remote_vars = {"a": "one.outputs.var", "b": "two.outputs.var"}
     def_prepare._app_state.terraform_options.backend_use_all_remotes = False
     def_prepare._app_state.backend.remotes = ["x", "y"]
 
     mock_get_remote_vars = mocker.patch.object(
-        Definition, "get_remote_vars", return_value={"a": "one.var", "b": "two.var"}
+        Definition,
+        "get_remote_vars",
+        return_value={"a": "one.outputs.var", "b": "two.outputs.var"},
     )
 
-    assert def_prepare._get_remotes("def1") == ["one", "two"]
+    assert set(def_prepare._get_remotes("def1")) == {"one", "two"}
     mock_get_remote_vars.assert_called_once_with(
         global_vars=def_prepare._app_state.loaded_config.global_vars.remote_vars
     )
@@ -251,17 +255,20 @@ def test_get_remotes(def_prepare, mocker, definition):
 
 
 def test_get_remotes_with_global_inheritance(def_prepare, mocker, definition):
-    definition.remote_vars = {"local_var": "local.state"}
+    definition.remote_vars = {"local_var": "local.outputs.state"}
     def_prepare._app_state.terraform_options.backend_use_all_remotes = False
 
     mock_get_remote_vars = mocker.patch.object(
         Definition,
         "get_remote_vars",
-        return_value={"local_var": "local.state", "global_var": "global.state"},
+        return_value={
+            "local_var": "local.outputs.state",
+            "global_var": "global.outputs.state",
+        },
     )
 
     result = def_prepare._get_remotes("def1")
-    assert result == ["local", "global"]
+    assert set(result) == {"local", "global"}
     mock_get_remote_vars.assert_called_once_with(
         global_vars=def_prepare._app_state.loaded_config.global_vars.remote_vars
     )
@@ -292,3 +299,337 @@ def test_get_template_vars(mocker, def_prepare, definition, monkeypatch):
     assert result["var"]["foo"] == "bar"
     assert result["var"]["baz"] == "qux"
     assert result["env"]["EXAMPLE"] == "value"
+
+
+# ===== Tests for nested remote_vars structures =====
+
+
+class TestCreateLocalVarsNested:
+    """Tests for create_local_vars with nested structures (dicts/lists)."""
+
+    def test_create_local_vars_with_dict_entire_outputs(
+        self, mocker, def_prepare, definition
+    ):
+        """Test creating locals with dict of entire outputs references."""
+        remote_vars = {
+            "vpcs": {
+                "platform": "network1.outputs",
+                "payments": "network2.outputs",
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        # Check structure
+        assert "locals {" in content
+        assert "vpcs = {" in content
+        assert '"platform" = data.terraform_remote_state.network1.outputs' in content
+        assert '"payments" = data.terraform_remote_state.network2.outputs' in content
+
+    def test_create_local_vars_with_dict_specific_keys(
+        self, mocker, def_prepare, definition
+    ):
+        """Test creating locals with dict of specific output keys."""
+        remote_vars = {
+            "vpc_configs": {
+                "platform": "network1.outputs.vpc_config",
+                "payments": "network2.outputs.vpc_config",
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "vpc_configs = {" in content
+        assert (
+            '"platform" = data.terraform_remote_state.network1.outputs.vpc_config'
+            in content
+        )
+        assert (
+            '"payments" = data.terraform_remote_state.network2.outputs.vpc_config'
+            in content
+        )
+
+    def test_create_local_vars_with_list(self, mocker, def_prepare, definition):
+        """Test creating locals with list of references."""
+        remote_vars = {
+            "vpc_ids": [
+                "network1.outputs.vpc_id",
+                "network2.outputs.vpc_id",
+                "network3.outputs.vpc_id",
+            ]
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "vpc_ids = [" in content
+        assert "data.terraform_remote_state.network1.outputs.vpc_id," in content
+        assert "data.terraform_remote_state.network2.outputs.vpc_id," in content
+        assert "data.terraform_remote_state.network3.outputs.vpc_id," in content
+
+    def test_create_local_vars_mixed_simple_and_complex(
+        self, mocker, def_prepare, definition
+    ):
+        """Test creating locals with mix of simple strings and complex structures."""
+        remote_vars = {
+            # Simple (existing)
+            "environment": "env_info.outputs.environment",
+            # Dict
+            "vpcs": {
+                "platform": "network1.outputs",
+                "payments": "network2.outputs",
+            },
+            # List
+            "vpc_ids": [
+                "network1.outputs.vpc_id",
+                "network2.outputs.vpc_id",
+            ],
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        # Simple string
+        assert (
+            "environment = data.terraform_remote_state.env_info.outputs.environment"
+            in content
+        )
+        # Dict
+        assert "vpcs = {" in content
+        assert '"platform" = data.terraform_remote_state.network1.outputs' in content
+        # List
+        assert "vpc_ids = [" in content
+        assert "data.terraform_remote_state.network1.outputs.vpc_id," in content
+
+    def test_create_local_vars_nested_dict_in_dict(
+        self, mocker, def_prepare, definition
+    ):
+        """Test creating locals with nested dict structures."""
+        remote_vars = {
+            "networks": {
+                "production": {
+                    "primary": "net1.outputs.vpc",
+                    "secondary": "net2.outputs.vpc",
+                },
+                "staging": {
+                    "primary": "net3.outputs.vpc",
+                },
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "networks = {" in content
+        assert '"production" = {' in content
+        assert '"primary" = data.terraform_remote_state.net1.outputs.vpc' in content
+        assert '"secondary" = data.terraform_remote_state.net2.outputs.vpc' in content
+        assert '"staging" = {' in content
+        assert '"primary" = data.terraform_remote_state.net3.outputs.vpc' in content
+
+    def test_create_local_vars_empty_dict(self, mocker, def_prepare, definition):
+        """Test creating locals with empty dict."""
+        remote_vars = {"empty": {}}
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "empty = {}" in content
+
+    def test_create_local_vars_empty_list(self, mocker, def_prepare, definition):
+        """Test creating locals with empty list."""
+        remote_vars = {"empty": []}
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "empty = []" in content
+
+
+class TestGetRemotesNested:
+    """Tests for _get_remotes with nested structures."""
+
+    def test_get_remotes_from_dict(self, mocker, def_prepare, definition):
+        """Test extracting remotes from dict structure."""
+        remote_vars = {
+            "vpcs": {
+                "platform": "network1.outputs",
+                "payments": "network2.outputs.vpc",
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert set(remotes) == {"network1", "network2"}
+
+    def test_get_remotes_from_list(self, mocker, def_prepare, definition):
+        """Test extracting remotes from list structure."""
+        remote_vars = {
+            "vpc_ids": [
+                "net1.outputs.vpc_id",
+                "net2.outputs.vpc_id",
+                "net3.outputs.vpc_id",
+            ]
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert set(remotes) == {"net1", "net2", "net3"}
+
+    def test_get_remotes_from_mixed_structures(self, mocker, def_prepare, definition):
+        """Test extracting remotes from mixed simple and complex structures."""
+        remote_vars = {
+            "env": "env_info.outputs.environment",
+            "vpcs": {
+                "platform": "network1.outputs",
+                "payments": "network2.outputs",
+            },
+            "db_endpoints": [
+                "db1.outputs.endpoint",
+                "db2.outputs.endpoint",
+            ],
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert set(remotes) == {"env_info", "network1", "network2", "db1", "db2"}
+
+    def test_get_remotes_deduplicates(self, mocker, def_prepare, definition):
+        """Test that duplicate state names are deduplicated."""
+        remote_vars = {
+            "vpc_id": "net1.outputs.vpc_id",
+            "subnet_ids": "net1.outputs.subnet_ids",
+            "cidr": "net1.outputs.cidr",
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert remotes == ["net1"]
+
+    def test_get_remotes_with_nested_dict(self, mocker, def_prepare, definition):
+        """Test extracting remotes from deeply nested structures."""
+        remote_vars = {
+            "networks": {
+                "production": {
+                    "primary": "net1.outputs",
+                    "secondary": "net2.outputs",
+                },
+                "staging": [
+                    "net3.outputs.vpc_id",
+                ],
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert set(remotes) == {"net1", "net2", "net3"}
+
+
+class TestGenerateTfValue:
+    """Tests for _generate_tf_value helper method."""
+
+    def test_generate_simple_string(self, def_prepare):
+        """Test generating HCL for simple string reference."""
+        result = def_prepare._generate_tf_value("network1.outputs.vpc_id")
+        assert result == "data.terraform_remote_state.network1.outputs.vpc_id"
+
+    def test_generate_string_entire_outputs(self, def_prepare):
+        """Test generating HCL for entire outputs reference."""
+        result = def_prepare._generate_tf_value("network1.outputs")
+        assert result == "data.terraform_remote_state.network1.outputs"
+
+    def test_generate_dict_single_level(self, def_prepare):
+        """Test generating HCL for single-level dict."""
+        value = {
+            "platform": "network1.outputs",
+            "payments": "network2.outputs",
+        }
+        result = def_prepare._generate_tf_value(value, indent=1)
+
+        assert "{" in result
+        assert '"platform" = data.terraform_remote_state.network1.outputs' in result
+        assert '"payments" = data.terraform_remote_state.network2.outputs' in result
+        assert "}" in result
+
+    def test_generate_list(self, def_prepare):
+        """Test generating HCL for list."""
+        value = [
+            "net1.outputs.vpc_id",
+            "net2.outputs.vpc_id",
+        ]
+        result = def_prepare._generate_tf_value(value, indent=1)
+
+        assert "[" in result
+        assert "data.terraform_remote_state.net1.outputs.vpc_id," in result
+        assert "data.terraform_remote_state.net2.outputs.vpc_id," in result
+        assert "]" in result
+
+    def test_generate_empty_dict(self, def_prepare):
+        """Test generating HCL for empty dict."""
+        result = def_prepare._generate_tf_value({})
+        assert result == "{}"
+
+    def test_generate_empty_list(self, def_prepare):
+        """Test generating HCL for empty list."""
+        result = def_prepare._generate_tf_value([])
+        assert result == "[]"
+
+    def test_generate_nested_dict(self, def_prepare):
+        """Test generating HCL for nested dict."""
+        value = {
+            "production": {
+                "primary": "net1.outputs",
+            }
+        }
+        result = def_prepare._generate_tf_value(value, indent=1)
+
+        assert '"production" = {' in result
+        assert '"primary" = data.terraform_remote_state.net1.outputs' in result
+
+    def test_generate_invalid_type(self, def_prepare):
+        """Test that invalid value type raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            def_prepare._generate_tf_value(123)  # Number not supported
+        assert "Unsupported remote_vars value type" in str(exc_info.value)

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -282,7 +282,11 @@ class TestMainBlocks:
         assert container["has_header_divider"] is True
         assert "is_collapsible" not in container
         subtitle = container["subtitle"]["text"]
-        assert "run `1234`" in subtitle and "updated" in subtitle
+        assert "run `1234`" in subtitle
+        # viewer-local start time and relative "updated" with UTC fallbacks
+        assert "started <!date^" in subtitle and "^{time}|" in subtitle
+        assert "updated <!date^" in subtitle and "^{ago}|" in subtitle
+        assert "UTC>" in subtitle
 
         status, counts, links = container["child_blocks"]
         assert "*Applying*" in status["text"]["text"]

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -384,6 +384,17 @@ class TestPlanBlock:
         queued = next(t for t in plan["tasks"] if t["task_id"] == "rollup_queued")
         assert "1 definitions queued" in queued["title"]
 
+    def test_no_changes_rollup_shown_mid_run(self):
+        board = make_board()
+        register(board, "clean", "busy")
+        finish_ok(board, "clean", changes=False)
+        board.mark("busy", TerraformAction.INIT, "running")
+        plan = board._build_main_blocks()[1]
+        no_changes = next(
+            t for t in plan["tasks"] if t["task_id"] == "rollup_no_changes"
+        )
+        assert "1 definitions with no changes" in no_changes["title"]
+
     def test_running_verb_follows_actual_action(self):
         board = make_board()
         register(board, "a", "b")

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -89,6 +89,7 @@ class TestSlackConfig:
         assert cfg.title is None
         assert cfg.definition_log_url_template is None
         assert cfg.update_interval == 4.0
+        assert cfg.timezone == "America/Chicago"
         assert cfg.links[0].url == "https://argo.example/wf/1"
 
     def test_token_not_exposed_in_repr(self):
@@ -286,7 +287,6 @@ class TestMainBlocks:
         # viewer-local start time and relative "updated" with UTC fallbacks
         assert "started <!date^" in subtitle and "^{time}|" in subtitle
         assert "updated <!date^" in subtitle and "^{ago}|" in subtitle
-        assert "UTC>" in subtitle
 
         status, counts, links = container["child_blocks"]
         assert "*Applying*" in status["text"]["text"]
@@ -371,22 +371,23 @@ class TestPlanBlock:
 
     def test_running_tasks_named_oldest_first_then_rolled_up(self):
         board = make_board()
-        register(board, *[f"def{i}" for i in range(6)])
-        for i in range(5):
-            board.mark(f"def{i}", TerraformAction.INIT, "running")
-        board._records["def3"].started_at = 0.5  # oldest
+        register(board, *[f"def{i:02d}" for i in range(14)])
+        for i in range(12):
+            board.mark(f"def{i:02d}", TerraformAction.INIT, "running")
+        board._records["def03"].started_at = 0.5  # oldest
 
         plan = board._build_main_blocks()[1]
+        assert plan["title"] == "📝 Run Details"
         named = [t for t in plan["tasks"] if t["task_id"].startswith("run_")]
         assert len(named) == board.MAX_NAMED_RUNNING
-        assert named[0]["task_id"] == "run_def3"
+        assert named[0]["task_id"] == "run_def03"
         # verbs follow the action actually running (init here), not the
         # run's primary verb ("applying")
         assert named[0]["title"].endswith("— initializing")
         rollup = next(t for t in plan["tasks"] if t["task_id"] == "rollup_running")
-        assert "3 more initializing" in rollup["title"]
+        assert "2 more initializing" in rollup["title"]
         queued = next(t for t in plan["tasks"] if t["task_id"] == "rollup_queued")
-        assert "1 definitions queued" in queued["title"]
+        assert "2 definitions queued" in queued["title"]
 
     def test_no_changes_rollup_shown_mid_run(self):
         board = make_board()
@@ -441,7 +442,7 @@ class TestPlanBlock:
             for t in board._build_main_blocks()[1]["tasks"]
             if t["task_id"] == "rollup_complete"
         )
-        assert "1 definitions applied cleanly" in rollup["title"]
+        assert "1 definitions applied" in rollup["title"]
         assert "5 resources changed" in rich_text(rollup["output"])
 
     def test_plans_stored_card_only_for_backend_plan_runs(self):

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -284,9 +285,12 @@ class TestMainBlocks:
         assert "is_collapsible" not in container
         subtitle = container["subtitle"]["text"]
         assert "run `1234`" in subtitle
-        # viewer-local start time and relative "updated" with UTC fallbacks
-        assert "started <!date^" in subtitle and "^{time}|" in subtitle
-        assert "updated <!date^" in subtitle and "^{ago}|" in subtitle
+        # plain clocks in the configured timezone: the container subtitle
+        # renders Slack's <!date> command literally rather than processing it
+        assert "<!date" not in subtitle
+        assert re.search(
+            r"started \d\d:\d\d C[DS]T · updated \d\d:\d\d C[DS]T", subtitle
+        )
 
         status, counts, links = container["child_blocks"]
         assert "*Applying*" in status["text"]["text"]

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -647,7 +647,6 @@ class TestSlackHandler:
         "options,definition,expected",
         [
             ({}, make_definition("d"), ["init", "plan"]),
-            ({}, make_definition("d", always_apply=True), ["init", "plan", "apply"]),
             (
                 {"plan": False, "destroy": True},
                 make_definition("d"),
@@ -664,6 +663,38 @@ class TestSlackHandler:
         handler = make_handler()
         handler.setup("apps-qa", {"d": definition}, "/tmp", make_options(**options))
         assert handler._board._expected_actions == expected
+
+    def test_always_apply_is_per_definition_not_run_wide(self):
+        handler = make_handler()
+        definitions = {
+            "normal": make_definition("normal"),
+            "always": make_definition("always", always_apply=True),
+        }
+        handler.setup("apps-qa", definitions, "/tmp", make_options())
+        board = handler._board
+
+        # one always_apply definition must not turn a plan run into an apply
+        assert board._primary_action == "plan"
+        assert board._records["normal"].expected == ["init", "plan"]
+        assert board._records["always"].expected == ["init", "plan", "apply"]
+
+        # the apply column appears, but only for the always_apply definition
+        table = board._build_thread_messages()[0][1]
+        assert [c["text"] for c in table["rows"][0]][:4] == [
+            "Definition",
+            "Init",
+            "Plan",
+            "Apply",
+        ]
+        normal_row, always_row = table["rows"][1], table["rows"][2]
+        assert normal_row[3] == {"type": "raw_text", "text": "—"}
+        assert always_row[3]["type"] == "rich_text"  # pending hourglass
+
+        # a planned-changes definition finishes at plan and counts as planned,
+        # not "no changes" from an apply expectation it never had
+        board.mark("normal", TerraformAction.INIT, "done")
+        board.mark("normal", TerraformAction.PLAN, "changes")
+        assert board._classify(board._records["normal"]) == "ok"
 
     @pytest.mark.parametrize(
         "action,result,expected_status",

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -1,845 +1,729 @@
 import os
+import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from slack_sdk.errors import SlackApiError
 
 from tfworker.commands.terraform import TerraformResult
 from tfworker.custom_types.terraform import TerraformAction, TerraformStage
-from tfworker.definitions.model import Definition
+from tfworker.handlers.slack import SlackConfig, SlackStatusBoard
+
+
+def make_config(**kwargs) -> SlackConfig:
+    kwargs.setdefault("channel", "#terraform")
+    kwargs.setdefault("token", "xoxb-test")
+    kwargs.setdefault("update_interval", 0.0)
+    return SlackConfig(**kwargs)
+
+
+def make_board(run_id="1234", backend_plans=False, **cfg_kwargs) -> SlackStatusBoard:
+    return SlackStatusBoard(
+        config=make_config(**cfg_kwargs), run_id=run_id, backend_plans=backend_plans
+    )
+
+
+def make_client() -> MagicMock:
+    client = MagicMock()
+    client.chat_postMessage.return_value = {"ts": "111.222", "channel": "C123"}
+    client.chat_update.return_value = {"ok": True}
+    return client
+
+
+def register(board: SlackStatusBoard, *names: str) -> None:
+    board.set_expected_actions(
+        [TerraformAction.INIT, TerraformAction.PLAN, TerraformAction.APPLY]
+    )
+    for name in names:
+        board.ensure_definition(name, "apps-qa", "/tmp")
+
+
+def finish_ok(board: SlackStatusBoard, name: str, changes: bool = True) -> None:
+    board.mark(name, TerraformAction.INIT, "done")
+    board.mark(name, TerraformAction.PLAN, "changes" if changes else "done")
+    board.mark(name, TerraformAction.APPLY, "done" if changes else "skipped")
+
+
+def fail_def(board: SlackStatusBoard, name: str, action=TerraformAction.APPLY) -> None:
+    board.mark(name, TerraformAction.INIT, "done")
+    if action != TerraformAction.INIT:
+        board.mark(name, TerraformAction.PLAN, "changes")
+    board.mark(name, action, "failed")
+    result = TerraformResult(1, b"", b"Error: something broke badly\nmore context")
+    board.record_result(name, action, result, failed=True)
+    # resolve remaining actions so the definition is terminal
+    for a in ("init", "plan", "apply"):
+        if a not in board._records[name].statuses:
+            board._records[name].statuses[a] = "skipped"
+
+
+def rich_text(block: dict) -> str:
+    return block["elements"][0]["elements"][0]["text"]
 
 
 class TestSlackConfig:
-    def test_requires_channel(self):
-        """channel is required."""
-        from tfworker.handlers.slack import SlackConfig
-
-        with pytest.raises(Exception):
-            SlackConfig()
-
-    def test_token_raw_value(self):
-        """token field is used directly when provided."""
-        from tfworker.handlers.slack import SlackConfig
-
-        cfg = SlackConfig(channel="#ops", token="xoxb-raw")
-        assert cfg.resolved_token == "xoxb-raw"
-
-    def test_token_from_default_env_var(self):
-        """Falls back to SLACK_BOT_TOKEN env var."""
-        from tfworker.handlers.slack import SlackConfig
-
-        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-from-env"}):
-            cfg = SlackConfig(channel="#ops")
-            assert cfg.resolved_token == "xoxb-from-env"
-
-    def test_token_from_custom_env_var(self):
-        """token_env overrides the default env var name."""
-        from tfworker.handlers.slack import SlackConfig
-
-        with patch.dict(os.environ, {"MY_TOKEN": "xoxb-custom"}, clear=False):
+    def test_token_resolution_order(self):
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-env"}):
+            assert SlackConfig(channel="#ops").resolved_token == "xoxb-env"
+            cfg = SlackConfig(channel="#ops", token="xoxb-raw")
+            assert cfg.resolved_token == "xoxb-raw"
+        with patch.dict(os.environ, {"MY_TOKEN": "xoxb-custom"}):
             cfg = SlackConfig(channel="#ops", token_env="MY_TOKEN")
             assert cfg.resolved_token == "xoxb-custom"
 
-    def test_token_raw_takes_precedence_over_env(self):
-        """Raw token takes precedence over env var."""
-        from tfworker.handlers.slack import SlackConfig
-
-        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-env"}):
-            cfg = SlackConfig(channel="#ops", token="xoxb-raw")
-            assert cfg.resolved_token == "xoxb-raw"
-
-    def test_missing_token_raises(self):
-        """Raises ValueError when no token is resolvable."""
-        from tfworker.handlers.slack import SlackConfig
-
-        env = {k: v for k, v in os.environ.items() if k != "SLACK_BOT_TOKEN"}
-        with patch.dict(os.environ, env, clear=True):
-            with pytest.raises((ValueError, Exception)):
-                SlackConfig(channel="#ops")
-
-    def test_defaults(self):
-        """Default values are correct."""
-        from tfworker.handlers.slack import SlackConfig
-
-        cfg = SlackConfig(channel="#ops", token="xoxb-x")
-        assert cfg.token_env == "SLACK_BOT_TOKEN"
-        assert cfg.title is None
-
-
-class TestSlackStatusBoard:
-    def _make_board(self):
-        from tfworker.handlers.slack import SlackStatusBoard
-
-        return SlackStatusBoard(channel="#ops", title=None, run_id=None)
-
-    def test_ensure_definition_registers_definition(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        assert "vpc" in board._statuses
-
-    def test_ensure_definition_captures_deployment_once(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.ensure_definition("eks", "other", "/tmp")
-        assert board._deployment == "prod"  # first call wins
-
-    def test_mark_sets_status(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "running")
-        assert board._statuses["vpc"]["plan"] == "running"
-
-    def test_mark_adds_action_to_seen_actions(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "running")
-        assert "plan" in board._seen_actions
-
-    def test_mark_maintains_action_order(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.APPLY, "running")
-        board.mark("vpc", TerraformAction.INIT, "done")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        assert board._seen_actions == ["init", "plan", "apply"]
-
-    def test_is_terminal_false_when_running(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "running")
-        assert board.is_terminal() is False
-
-    def test_is_terminal_false_when_pending(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.INIT, "done")
-        board.mark("vpc", TerraformAction.PLAN, "running")
-        assert board.is_terminal() is False
-
-    def test_is_terminal_true_when_all_done(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.INIT, "done")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        assert board.is_terminal() is True
-
-    def test_is_terminal_true_when_failed(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "failed")
-        assert board.is_terminal() is True
-
-    def test_overall_status_in_progress(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "running")
-        assert board.overall_status() == "in_progress"
-
-    def test_overall_status_done(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        assert board.overall_status() == "done"
-
-    def test_overall_status_failed(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "failed")
-        assert board.overall_status() == "failed"
-
-    def test_failed_count(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.ensure_definition("eks", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "failed")
-        board.mark("eks", TerraformAction.PLAN, "done")
-        assert board.failed_count() == 1
-
-    def test_skipped_count(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.ensure_definition("eks", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "skipped")
-        board.mark("eks", TerraformAction.PLAN, "done")
-        assert board.skipped_count() == 1
-
-
-class TestSlackStatusBoardGitContext:
-    def _make_board(self):
-        from tfworker.handlers.slack import SlackStatusBoard
-
-        return SlackStatusBoard(channel="#ops", title=None, run_id=None)
-
-    def test_github_actions_env_vars(self):
-        board = self._make_board()
-        env = {
-            "GITHUB_REF_NAME": "main",
-            "GITHUB_SHA": "abc1234567",
-            "CI_COMMIT_REF_NAME": "",
-            "CI_COMMIT_SHA": "",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            result = board._resolve_git_context("/tmp")
-        assert "main" in result
-        assert "abc1234" in result
-
-    def test_gitlab_ci_env_vars(self):
-        board = self._make_board()
-        env = {
-            "CI_COMMIT_REF_NAME": "feature/x",
-            "CI_COMMIT_SHA": "def7890123",
-            "GITHUB_REF_NAME": "",
-            "GITHUB_SHA": "",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            result = board._resolve_git_context("/tmp")
-        assert "feature/x" in result
-        assert "def7890" in result
-
-    def test_falls_back_to_git_subprocess(self):
-        board = self._make_board()
-        env = {
-            k: v
-            for k, v in os.environ.items()
-            if k
-            not in (
-                "GITHUB_REF_NAME",
-                "GITHUB_SHA",
-                "CI_COMMIT_REF_NAME",
-                "CI_COMMIT_SHA",
-            )
-        }
-        with patch.dict(os.environ, env, clear=True):
-            with patch("subprocess.check_output") as mock_sub:
-                mock_sub.side_effect = [b"mybranch\n", b"a1b2c3d\n"]
-                result = board._resolve_git_context("/some/dir")
-        assert "mybranch" in result
-        assert "a1b2c3d" in result
-
-    def test_returns_none_on_complete_failure(self):
-        board = self._make_board()
-        env = {
-            k: v
-            for k, v in os.environ.items()
-            if k
-            not in (
-                "GITHUB_REF_NAME",
-                "GITHUB_SHA",
-                "CI_COMMIT_REF_NAME",
-                "CI_COMMIT_SHA",
-            )
-        }
-        with patch.dict(os.environ, env, clear=True):
-            with patch("subprocess.check_output", side_effect=Exception("no git")):
-                result = board._resolve_git_context("/some/dir")
-        assert result is None
-
-
-class TestSlackStatusBoardSummary:
-    """The compact parent message: header, git context, banner, counts."""
-
-    def _make_board(self, title=None, run_id=None):
-        from tfworker.handlers.slack import SlackStatusBoard
-
-        b = SlackStatusBoard(channel="#ops", title=title, run_id=run_id)
-        b._deployment = "prod"
-        return b
-
-    def test_summary_is_list(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_summary_blocks()
-        assert isinstance(blocks, list)
-        assert len(blocks) >= 1
-
-    def test_header_block_contains_deployment(self):
-        board = self._make_board()
-        header = board._build_summary_blocks()[0]
-        assert header["type"] == "header"
-        assert "prod" in header["text"]["text"]
-
-    def test_header_uses_title_when_set(self):
-        board = self._make_board(title="My Run")
-        assert "My Run" in board._build_summary_blocks()[0]["text"]["text"]
-
-    def test_header_includes_run_id(self):
-        board = self._make_board(run_id="run-42")
-        assert "run-42" in board._build_summary_blocks()[0]["text"]["text"]
-
-    def test_git_context_present_when_available(self):
-        board = self._make_board()
-        board._git_context = "Branch: main  Commit: abc1234"
-        blocks = board._build_summary_blocks()
-        assert any(b.get("type") == "context" and "main" in str(b) for b in blocks)
-
-    def test_banner_in_progress(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "running")
-        assert "🟡" in str(board._build_summary_blocks())
-
-    def test_banner_done(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        assert "✅" in str(board._build_summary_blocks())
-
-    def test_banner_failed(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "failed")
-        assert "❌" in str(board._build_summary_blocks())
-
-    def test_banner_done_with_skips(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.INIT, "done")
-        board.mark("vpc", TerraformAction.PLAN, "skipped")
-        text = str(board._build_summary_blocks())
-        assert "✅" in text
-        assert "skipped" in text
-
-    def test_banner_done_no_skips(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        assert "succeeded" in str(board._build_summary_blocks())
-
-    def test_summary_includes_definition_count(self):
-        board = self._make_board()
-        for name in ["vpc", "eks", "rds"]:
-            board.ensure_definition(name, "prod", "/tmp")
-            board.mark(name, TerraformAction.PLAN, "done")
-        assert "3" in str(board._build_summary_blocks())
-
-    def test_summary_points_to_thread(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        assert "thread" in str(board._build_summary_blocks()).lower()
-
-
-class TestSlackStatusBoardDetail:
-    """The threaded per-definition table, chunked under Slack's block limit."""
-
-    def _make_board(self, title=None, run_id=None):
-        from tfworker.handlers.slack import SlackStatusBoard
-
-        b = SlackStatusBoard(channel="#ops", title=title, run_id=run_id)
-        b._deployment = "prod"
-        return b
-
-    def test_detail_contains_definition_name(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        assert "vpc" in str(board._build_detail_chunks())
-
-    def test_detail_contains_action_column(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        assert "Plan" in str(board._build_detail_chunks())
-
-    def test_only_observed_actions_as_columns(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.INIT, "done")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        text = str(board._build_detail_chunks())
-        assert "Apply" not in text
-        assert "Destroy" not in text
-
-    def test_chunk_uses_fields_layout(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        chunk = board._build_detail_chunks()[0]
-        fields_sections = [
-            b for b in chunk if b.get("type") == "section" and "fields" in b
-        ]
-        assert len(fields_sections) >= 2  # header row + at least one definition row
-
-    def test_chunk_header_fields_structure(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        chunk = board._build_detail_chunks()[0]
-        header = [b for b in chunk if b.get("type") == "section" and "fields" in b][0]
-        assert len(header["fields"]) == 2
-        assert header["fields"][0]["text"] == "*Definition*"
-        assert "*Plan*" in header["fields"][1]["text"]
-
-    def test_chunk_definition_row_structure(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        chunk = board._build_detail_chunks()[0]
-        rows = [b for b in chunk if b.get("type") == "section" and "fields" in b]
-        def_row = rows[1]
-        assert "`vpc`" in def_row["fields"][0]["text"]
-        assert "✅" in def_row["fields"][1]["text"]
-
-    def test_multiple_definitions_one_chunk(self):
-        board = self._make_board()
-        for name in ["vpc", "eks", "rds"]:
-            board.ensure_definition(name, "prod", "/tmp")
-            board.mark(name, TerraformAction.PLAN, "done")
-        chunks = board._build_detail_chunks()
-        assert len(chunks) == 1
-        rows = [
-            b for b in chunks[0] if b.get("type") == "section" and "fields" in b
-        ]
-        assert len(rows) == 4  # 1 header + 3 definition rows
-
-    def test_row_section_blocks_have_no_text_key(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        for block in board._build_detail_chunks()[0]:
-            if block.get("type") == "section" and "fields" in block:
-                assert "text" not in block
-
-    def test_large_board_splits_under_block_limit(self):
-        """Many definitions split into multiple messages, each under Slack's limit."""
-        board = self._make_board()
-        for i in range(60):
-            name = f"svc_{i:02d}"
-            board.ensure_definition(name, "prod", "/tmp")
-            board.mark(name, TerraformAction.INIT, "pending")
-            board.mark(name, TerraformAction.PLAN, "pending")
-        chunks = board._build_detail_chunks()
-        assert len(chunks) == 2  # ceil(60 / DETAIL_ROWS_PER_MSG=45)
-        for chunk in chunks:
-            assert len(chunk) <= board.MAX_BLOCKS
-
-    def test_no_chunks_when_no_actions(self):
-        board = self._make_board()
-        assert board._build_detail_chunks() == []
-
-
-class TestSlackStatusBoardPostOrUpdate:
-    def _make_board(self):
-        from tfworker.handlers.slack import SlackStatusBoard
-
-        b = SlackStatusBoard(channel="#ops", title=None, run_id=None)
-        b._deployment = "prod"
-        b.ensure_definition("vpc", "prod", "/tmp")
-        b.mark("vpc", TerraformAction.PLAN, "running")
-        return b
-
-    def _mock_client(self):
-        client = MagicMock()
-        client.chat_postMessage.return_value = {"ts": "111.222", "channel": "C123"}
-        return client
-
-    def test_first_call_posts_parent_and_thread(self):
-        board = self._make_board()
-        client = self._mock_client()
-        board.post_or_update(client)
-        # parent summary message + one threaded detail message
-        assert client.chat_postMessage.call_count == 2
-        client.chat_update.assert_not_called()
-        first, second = client.chat_postMessage.call_args_list
-        assert first.kwargs.get("thread_ts") is None  # parent (thread root)
-        assert second.kwargs.get("thread_ts") == "111.222"  # threaded detail
-
-    def test_first_call_stores_ts(self):
-        board = self._make_board()
-        client = self._mock_client()
-        board.post_or_update(client)
-        assert board._ts == "111.222"
-
-    def test_second_call_uses_update(self):
-        board = self._make_board()
-        client = self._mock_client()
-        board.post_or_update(client)
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        board.post_or_update(client)
-        # both the parent summary and the changed detail chunk are updated
-        assert client.chat_update.called
-
-    def test_unchanged_second_call_is_noop(self):
-        board = self._make_board()
-        client = self._mock_client()
-        board.post_or_update(client)
-        board.post_or_update(client)  # nothing changed
-        client.chat_update.assert_not_called()
-
-    def test_update_uses_stored_ts(self):
-        board = self._make_board()
-        client = self._mock_client()
-        board.post_or_update(client)
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        board.post_or_update(client)
-        assert client.chat_update.called
-        for call in client.chat_update.call_args_list:
-            assert call.kwargs["ts"] == "111.222"
-
-    def test_slack_error_is_logged_not_raised(self):
-        board = self._make_board()
-        client = MagicMock()
-        client.chat_postMessage.side_effect = Exception("api down")
-        # Must not raise
-        board.post_or_update(client)
-
-
-class TestSlackHandlerInit:
-    def _make_config(self, **kwargs):
-        from tfworker.handlers.slack import SlackConfig
-
-        return SlackConfig(channel="#ops", token="xoxb-test", **kwargs)
-
-    def test_is_ready_after_init(self):
-        from tfworker.handlers.slack import SlackHandler
-
-        with patch("tfworker.handlers.slack.WebClient"):
-            handler = SlackHandler(self._make_config())
-        assert handler.is_ready() is True
-
-    def test_missing_token_raises_handler_error(self):
-        from tfworker.handlers.slack import SlackConfig
-
+    def test_missing_token_or_channel_raises(self):
         env = {k: v for k, v in os.environ.items() if k != "SLACK_BOT_TOKEN"}
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(Exception):
                 SlackConfig(channel="#ops")
+        with pytest.raises(Exception):
+            SlackConfig(token="xoxb-x")
+
+    def test_defaults_and_links(self):
+        cfg = SlackConfig(
+            channel="#ops",
+            token="xoxb-x",
+            links=[{"text": "Argo", "url": "https://argo.example/wf/1"}],
+        )
+        assert cfg.title is None
+        assert cfg.definition_log_url_template is None
+        assert cfg.update_interval == 4.0
+        assert cfg.links[0].url == "https://argo.example/wf/1"
 
     def test_token_not_exposed_in_repr(self):
-        from tfworker.handlers.slack import SlackConfig
-
-        config = SlackConfig(channel="#ops", token="xoxb-super-secret")
-        assert "xoxb-super-secret" not in repr(config)
-
-    def test_handler_stores_board(self):
-        from tfworker.handlers.slack import SlackHandler, SlackStatusBoard
-
-        with patch("tfworker.handlers.slack.WebClient"):
-            handler = SlackHandler(self._make_config())
-        assert isinstance(handler._board, SlackStatusBoard)
-
-    def test_actions_includes_all_terraform_actions(self):
-        from tfworker.handlers.slack import SlackHandler
-
-        assert TerraformAction.INIT in SlackHandler.actions
-        assert TerraformAction.PLAN in SlackHandler.actions
-        assert TerraformAction.APPLY in SlackHandler.actions
-        assert TerraformAction.DESTROY in SlackHandler.actions
+        assert "xoxb-secret" not in repr(SlackConfig(channel="#o", token="xoxb-secret"))
 
 
-class TestSlackHandlerExecute:
-    def _make_handler(self):
-        from tfworker.handlers.slack import SlackConfig, SlackHandler
-
-        cfg = SlackConfig(channel="#ops", token="xoxb-test")
-        with patch("tfworker.handlers.slack.WebClient"):
-            handler = SlackHandler(cfg)
-        handler._client = MagicMock()
-        handler._client.chat_postMessage.return_value = {"ts": "1.2", "channel": "C1"}
-        return handler
-
-    def _make_definition(self, name="vpc"):
-        return Definition(name=name, path="/tmp")
-
-    def test_pre_marks_running_and_posts(self):
-        handler = self._make_handler()
-        defn = self._make_definition()
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-        assert handler._board._statuses["vpc"]["plan"] == "running"
-        assert handler._client.chat_postMessage.called
-
-    def test_post_success_marks_done_and_updates(self):
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(0, b"ok", b"")
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.PLAN, TerraformStage.POST, "prod", defn, "/tmp", result
+class TestBoardState:
+    def test_expected_actions_ordered_and_primary_derived(self):
+        board = make_board()
+        board.set_expected_actions(
+            [TerraformAction.APPLY, TerraformAction.INIT, TerraformAction.PLAN]
         )
-        assert handler._board._statuses["vpc"]["plan"] == "done"
-        assert handler._client.chat_update.called
+        assert board._expected_actions == ["init", "plan", "apply"]
+        assert board._primary_action == "apply"
+        board.set_expected_actions([TerraformAction.INIT, TerraformAction.DESTROY])
+        assert board._primary_action == "destroy"
 
-    def test_post_failure_marks_failed_and_updates(self):
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(1, b"", b"error!")
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.PLAN, TerraformStage.POST, "prod", defn, "/tmp", result
+    def test_classification_buckets(self):
+        board = make_board()
+        register(board, "queued", "running", "ok", "failed", "skipped")
+        board.mark("running", TerraformAction.INIT, "running")
+        finish_ok(board, "ok")
+        fail_def(board, "failed")
+        for action in ("init", "plan", "apply"):
+            board._records["skipped"].statuses[action] = "skipped"
+
+        buckets = board._buckets()
+        for bucket in ("queued", "running", "ok", "failed", "skipped"):
+            assert [r.name for r in buckets[bucket]] == [bucket]
+
+    def test_overall_status_transitions(self):
+        board = make_board()
+        register(board, "a", "b")
+        assert board.overall_status() == "in_progress"
+        finish_ok(board, "a")
+        assert board.overall_status() == "in_progress"
+        finish_ok(board, "b")
+        assert board.overall_status() == "done"
+        fail_def(board, "a")
+        assert board.overall_status() == "failed"
+
+    def test_changes_status_is_terminal_and_not_failed(self):
+        board = make_board()
+        board.set_expected_actions([TerraformAction.INIT, TerraformAction.PLAN])
+        board.ensure_definition("a", "apps-qa", "/tmp")
+        board.mark("a", TerraformAction.INIT, "done")
+        board.mark("a", TerraformAction.PLAN, "changes")
+        assert board.overall_status() == "done"
+
+    def test_mark_tracks_definition_duration(self):
+        board = make_board()
+        register(board, "vpc")
+        board.mark("vpc", TerraformAction.INIT, "running")
+        assert board._records["vpc"].started_at is not None
+        finish_ok(board, "vpc")
+        assert board._records["vpc"].duration_secs() is not None
+
+
+class TestResultParsing:
+    def test_plan_and_apply_output_parsed(self):
+        board = make_board()
+        register(board, "vpc", "eks", "rds")
+        board.record_result(
+            "vpc",
+            TerraformAction.PLAN,
+            TerraformResult(
+                2, b"...\nPlan: 3 to add, 12 to change, 1 to destroy.\n", b""
+            ),
         )
-        assert handler._board._statuses["vpc"]["plan"] == "failed"
-
-    def test_error_stage_marks_failed_and_updates(self):
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(1, b"", b"boom")
-        handler.execute(TerraformAction.APPLY, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.APPLY, TerraformStage.ERROR, "prod", defn, "/tmp", result
+        board.record_result(
+            "eks",
+            TerraformAction.PLAN,
+            TerraformResult(0, b"No changes. Infrastructure is up-to-date.", b""),
         )
-        assert handler._board._statuses["vpc"]["apply"] == "failed"
-        assert handler._client.chat_update.called
-
-    def test_multiple_definitions_tracked(self):
-        handler = self._make_handler()
-        vpc = self._make_definition("vpc")
-        eks = self._make_definition("eks")
-        handler.execute(TerraformAction.INIT, TerraformStage.PRE, "prod", vpc, "/tmp")
-        handler.execute(TerraformAction.INIT, TerraformStage.PRE, "prod", eks, "/tmp")
-        assert "vpc" in handler._board._statuses
-        assert "eks" in handler._board._statuses
-
-    def test_execute_never_raises_on_slack_failure(self):
-        handler = self._make_handler()
-        handler._client.chat_postMessage.side_effect = Exception("Slack is down")
-        defn = self._make_definition()
-        # Must not raise
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-
-    def test_plan_exit_code_2_marks_changes(self):
-        """Exit code 2 on a plan means changes detected — not an error."""
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(2, b"Plan: 1 to add", b"")
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.PLAN, TerraformStage.POST, "prod", defn, "/tmp", result
+        board.record_result(
+            "rds",
+            TerraformAction.APPLY,
+            TerraformResult(
+                0, b"Apply complete! Resources: 3 added, 12 changed, 1 destroyed.", b""
+            ),
         )
-        assert handler._board._statuses["vpc"]["plan"] == "changes"
-
-    def test_plan_exit_code_0_marks_done(self):
-        """Exit code 0 on a plan means no changes."""
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(0, b"No changes.", b"")
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.PLAN, TerraformStage.POST, "prod", defn, "/tmp", result
+        assert board._records["vpc"].planned_changes == 16
+        assert (
+            board._records["vpc"].plan_line
+            == "Plan: 3 to add, 12 to change, 1 to destroy"
         )
-        assert handler._board._statuses["vpc"]["plan"] == "done"
+        assert board._records["eks"].planned_changes == 0
+        assert board._records["rds"].applied_changes == 16
 
-    def test_plan_exit_code_1_marks_failed(self):
-        """Exit code 1 on a plan means an error."""
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(1, b"", b"Error: something broke")
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.PLAN, TerraformStage.POST, "prod", defn, "/tmp", result
+    def test_error_snippet_extracted_and_ansi_stripped(self):
+        board = make_board()
+        register(board, "vpc", "eks")
+        board.record_result(
+            "vpc",
+            TerraformAction.APPLY,
+            TerraformResult(
+                1, b"", b"\x1b[31mError: creating EventBus: AccessDenied\x1b[0m\ndetail"
+            ),
+            failed=True,
         )
-        assert handler._board._statuses["vpc"]["plan"] == "failed"
-
-    def test_exit_code_2_on_non_plan_action_marks_failed(self):
-        """Exit code 2 is only meaningful for plan; treat as failure for other actions."""
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(2, b"", b"unexpected")
-        handler.execute(TerraformAction.APPLY, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.APPLY, TerraformStage.POST, "prod", defn, "/tmp", result
+        board.record_result(
+            "eks",
+            TerraformAction.PLAN,
+            TerraformResult(1, b"", b"something\nwent wrong"),
+            failed=True,
         )
-        assert handler._board._statuses["vpc"]["apply"] == "failed"
+        rec = board._records["vpc"]
+        assert rec.error_action == "apply"
+        assert "AccessDenied" in rec.error_snippet
+        assert "\x1b" not in rec.error_snippet
+        # no "Error:" line falls back to the tail of the output
+        assert "went wrong" in board._records["eks"].error_snippet
 
-    def test_changes_status_is_terminal(self):
-        """A plan with changes should be considered terminal, not stuck pending."""
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(2, b"Plan: 1 to add", b"")
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.PLAN, TerraformStage.POST, "prod", defn, "/tmp", result
+    def test_none_result_is_ignored(self):
+        board = make_board()
+        register(board, "vpc")
+        board.record_result("vpc", TerraformAction.APPLY, None, failed=True)
+        assert board._records["vpc"].error_snippet is None
+
+
+class TestGitContext:
+    def test_ci_env_vars(self):
+        board = make_board()
+        env = {"GITHUB_REF_NAME": "main", "GITHUB_SHA": "abcdef1234567890"}
+        with patch.dict(os.environ, env):
+            board.ensure_definition("vpc", "apps-qa", "/tmp")
+        assert board._branch == "main"
+        assert board._commit == "abcdef1"
+
+    def test_git_failure_leaves_none(self):
+        board = make_board()
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in (
+                "GITHUB_REF_NAME",
+                "GITHUB_SHA",
+                "CI_COMMIT_REF_NAME",
+                "CI_COMMIT_SHA",
+            )
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch(
+                "tfworker.handlers.slack.subprocess.check_output",
+                side_effect=OSError("no git"),
+            ):
+                board.ensure_definition("vpc", "apps-qa", "/tmp")
+        assert board._branch is None
+        assert board._commit is None
+
+
+class TestMainBlocks:
+    def test_in_progress_layout(self):
+        board = make_board(
+            title="apps/qa",
+            links=[{"text": "Argo workflow", "url": "https://argo.example/wf"}],
         )
-        assert handler._board.is_terminal() is True
+        register(board, *[f"def{i}" for i in range(131)])
+        finish_ok(board, "def0")
+        board.mark("def1", TerraformAction.APPLY, "running")
+        board.mark("def2", TerraformAction.APPLY, "running")
 
-    def test_changes_status_does_not_count_as_failed(self):
-        """overall_status should be 'done' when all plans show changes, not 'failed'."""
-        handler = self._make_handler()
-        defn = self._make_definition()
-        result = TerraformResult(2, b"Plan: 1 to add", b"")
-        handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
-        handler.execute(
-            TerraformAction.PLAN, TerraformStage.POST, "prod", defn, "/tmp", result
+        blocks = board._build_main_blocks()
+        assert [b["type"] for b in blocks] == ["container", "plan"]
+
+        container = blocks[0]
+        assert container["title"]["text"] == "Apply — apps/qa"
+        assert container["has_header_divider"] is True
+        assert "is_collapsible" not in container
+        subtitle = container["subtitle"]["text"]
+        assert "run `1234`" in subtitle and "updated" in subtitle
+
+        status, counts, links = container["child_blocks"]
+        assert "*Applying*" in status["text"]["text"]
+        assert "2 definitions running" in status["text"]["text"]
+        assert "1 of 131 finished" in status["text"]["text"]
+        counts_text = " ".join(e["text"] for e in counts["elements"])
+        assert "*131* definitions" in counts_text
+        assert "*1* applied" in counts_text
+        assert "*2* running" in counts_text
+        assert "*128* queued" in counts_text
+        assert "<https://argo.example/wf|Argo workflow>" in links["elements"][0]["text"]
+
+    def test_success_final_layout(self):
+        board = make_board()
+        register(board, "a", "b")
+        finish_ok(board, "a")
+        finish_ok(board, "b", changes=False)
+
+        container, plan = board._build_main_blocks()
+        assert container["is_collapsible"] is True
+        assert "has_header_divider" not in container
+        assert "finished in" in container["subtitle"]["text"]
+        verdict = container["child_blocks"][0]["text"]["text"]
+        assert "Run complete — 2 definitions succeeded" in verdict
+
+        assert all(t["status"] == "complete" for t in plan["tasks"])
+        skipped = next(t for t in plan["tasks"] if t["task_id"] == "rollup_skipped")
+        assert "1 definitions skipped" in skipped["title"]
+
+    def test_failed_final_layout(self):
+        board = make_board()
+        register(board, *[f"def{i}" for i in range(9)])
+        finish_ok(board, "def8")
+        for i in range(8):
+            fail_def(board, f"def{i}")
+
+        blocks = board._build_main_blocks()
+        # the plan block is dropped in favor of the container's failure table
+        assert len(blocks) == 1
+        container = blocks[0]
+        verdict = container["child_blocks"][0]["text"]["text"]
+        assert "Run failed — 8 of 9 definitions errored" in verdict
+
+        table = next(c for c in container["child_blocks"] if c["type"] == "table")
+        assert len(table["rows"]) == 1 + board.MAX_FAILURE_TABLE_ROWS
+        assert table["rows"][1][1]["text"] == "apply"
+        assert len(table["rows"][1][2]["text"]) <= board.FAILURE_ERROR_CHARS
+        more = container["child_blocks"][-1]["elements"][0]["text"]
+        assert "*3 more* failures" in more
+
+
+class TestPlanBlock:
+    def test_fresh_block_id_per_update(self):
+        board = make_board()
+        register(board, "a")
+        board._seq = 1
+        first = board._build_main_blocks()[1]["block_id"]
+        board._seq = 2
+        assert first != board._build_main_blocks()[1]["block_id"]
+
+    def test_error_cards_capped_with_datadog_sources(self):
+        board = make_board(
+            definition_log_url_template="https://dd.example/logs?q={definition}"
         )
-        assert handler._board.overall_status() == "done"
+        register(board, *[f"def{i}" for i in range(10)])
+        for i in range(8):
+            fail_def(board, f"def{i}")
+        board.mark("def8", TerraformAction.INIT, "running")
+
+        plan = board._build_main_blocks()[1]
+        errors = [t for t in plan["tasks"] if t["status"] == "error"]
+        assert len(errors) == board.MAX_ERROR_CARDS
+        assert errors[0]["sources"][0]["url"] == "https://dd.example/logs?q=def0"
+
+    def test_running_tasks_named_oldest_first_then_rolled_up(self):
+        board = make_board()
+        register(board, *[f"def{i}" for i in range(6)])
+        for i in range(5):
+            board.mark(f"def{i}", TerraformAction.INIT, "running")
+        board._records["def3"].started_at = 0.5  # oldest
+
+        plan = board._build_main_blocks()[1]
+        named = [t for t in plan["tasks"] if t["task_id"].startswith("run_")]
+        assert len(named) == board.MAX_NAMED_RUNNING
+        assert named[0]["task_id"] == "run_def3"
+        rollup = next(t for t in plan["tasks"] if t["task_id"] == "rollup_running")
+        assert "3 more" in rollup["title"]
+        queued = next(t for t in plan["tasks"] if t["task_id"] == "rollup_queued")
+        assert "1 definitions queued" in queued["title"]
+
+    def test_running_task_shows_plan_line(self):
+        board = make_board()
+        register(board, "a")
+        board.record_result(
+            "a",
+            TerraformAction.PLAN,
+            TerraformResult(2, b"Plan: 3 to add, 0 to change, 0 to destroy.", b""),
+        )
+        board.mark("a", TerraformAction.APPLY, "running")
+        card = next(
+            t for t in board._build_main_blocks()[1]["tasks"] if t["task_id"] == "run_a"
+        )
+        assert "3 to add" in rich_text(card["details"])
+
+    def test_complete_rollup_aggregates_resources(self):
+        board = make_board()
+        register(board, "a", "b")
+        finish_ok(board, "a")
+        board.record_result(
+            "a",
+            TerraformAction.APPLY,
+            TerraformResult(
+                0, b"Apply complete! Resources: 2 added, 3 changed, 0 destroyed.", b""
+            ),
+        )
+        board.mark("b", TerraformAction.INIT, "running")
+        rollup = next(
+            t
+            for t in board._build_main_blocks()[1]["tasks"]
+            if t["task_id"] == "rollup_complete"
+        )
+        assert "1 definitions applied cleanly" in rollup["title"]
+        assert "5 resources changed" in rich_text(rollup["output"])
+
+    def test_plans_stored_card_only_for_backend_plan_runs(self):
+        board = make_board(run_id="42", backend_plans=True)
+        board.set_expected_actions([TerraformAction.INIT, TerraformAction.PLAN])
+        board.ensure_definition("a", "apps-qa", "/tmp")
+        board.mark("a", TerraformAction.INIT, "done")
+        board.mark("a", TerraformAction.PLAN, "changes")
+        board.record_result(
+            "a",
+            TerraformAction.PLAN,
+            TerraformResult(2, b"Plan: 1 to add, 0 to change, 0 to destroy.", b""),
+        )
+        plan = board._build_main_blocks()[1]
+        stored = next(t for t in plan["tasks"] if t["task_id"] == "rollup_plans")
+        assert "run 42" in rich_text(stored["output"])
+
+        apply_board = make_board(backend_plans=True)
+        register(apply_board, "a")
+        finish_ok(apply_board, "a")
+        tasks = apply_board._build_main_blocks()[1]["tasks"]
+        assert not any(t["task_id"] == "rollup_plans" for t in tasks)
 
 
-class TestSlackHandlerRegistry:
-    def test_registered_as_slack(self):
-        import tfworker.handlers.slack  # noqa: F401
-        from tfworker.handlers.registry import HandlerRegistry
+class TestThreadMessages:
+    def test_table_layout_and_cell_types(self):
+        board = make_board()
+        register(board, "vpc")
+        board.mark("vpc", TerraformAction.INIT, "done")
+        board.mark("vpc", TerraformAction.PLAN, "failed")
+        board.mark("vpc", TerraformAction.APPLY, "skipped")
 
-        handler_cls = HandlerRegistry.get_handler("slack")
-        from tfworker.handlers.slack import SlackHandler
-
-        assert handler_cls is SlackHandler
-
-    def test_config_model_is_slack_config(self):
-        import tfworker.handlers.slack  # noqa: F401
-        from tfworker.handlers.registry import HandlerRegistry
-        from tfworker.handlers.slack import SlackConfig
-
-        model = HandlerRegistry.get_handler_config_model("slack")
-        assert model is SlackConfig
-
-
-class TestSlackHandlerSetup:
-    def _make_handler(self):
-        from tfworker.handlers.slack import SlackConfig, SlackHandler
-
-        cfg = SlackConfig(channel="#ops", token="xoxb-test")
-        with patch("tfworker.handlers.slack.WebClient"):
-            h = SlackHandler(cfg)
-        h._client = MagicMock()
-        h._client.chat_postMessage.return_value = {"ts": "1.2", "channel": "C1"}
-        return h
-
-    def _defs(self, names=("vpc", "eks"), always_apply=False):
-        objs = [
-            Definition(name=n, path="/tmp", always_apply=always_apply) for n in names
+        heading, table = board._build_thread_messages()[0]
+        assert "Per-definition results" in heading["text"]["text"]
+        assert table["type"] == "data_table"
+        assert [c["text"] for c in table["rows"][0]] == [
+            "Definition",
+            "Init",
+            "Plan",
+            "Apply",
+            "Changed",
+            "Secs",
         ]
-        m = MagicMock()
-        m.values.return_value = objs
-        return m
+        row = table["rows"][1]
+        assert rich_text(row[0]) == "vpc"
+        assert row[1]["elements"][0]["elements"][0]["name"] == "white_check_mark"
+        assert row[2]["elements"][0]["elements"][0]["name"] == "x"
+        # skipped and unknown numerics render as raw_text em dashes
+        assert row[3] == {"type": "raw_text", "text": "—"}
+        assert row[4] == {"type": "raw_text", "text": "—"}
 
-    def _opts(self, plan=True, apply=False, destroy=False, plan_destroy=False):
-        o = MagicMock()
-        o.plan = plan
-        o.apply = apply
-        o.destroy = destroy
-        o.plan_destroy = plan_destroy
-        return o
-
-    def test_registers_all_definitions(self):
-        h = self._make_handler()
-        h.setup("prod", self._defs(["vpc", "eks"]), "/tmp", self._opts())
-        assert "vpc" in h._board._statuses
-        assert "eks" in h._board._statuses
-
-    def test_seeds_pending_for_plan_action(self):
-        h = self._make_handler()
-        h.setup("prod", self._defs(["vpc"]), "/tmp", self._opts(plan=True))
-        assert h._board._statuses["vpc"].get("plan") == "pending"
-
-    def test_init_always_included(self):
-        h = self._make_handler()
-        h.setup("prod", self._defs(["vpc"]), "/tmp", self._opts(plan=False))
-        assert "init" in h._board._seen_actions
-
-    def test_apply_inferred_from_option(self):
-        h = self._make_handler()
-        h.setup("prod", self._defs(["vpc"]), "/tmp", self._opts(apply=True))
-        assert "apply" in h._board._seen_actions
-
-    def test_apply_inferred_from_always_apply_definition(self):
-        h = self._make_handler()
-        h.setup(
-            "prod",
-            self._defs(["vpc"], always_apply=True),
-            "/tmp",
-            self._opts(apply=False),
+    def test_numeric_cells_are_raw_text(self):
+        board = make_board()
+        register(board, "a")
+        finish_ok(board, "a")
+        board.record_result(
+            "a",
+            TerraformAction.APPLY,
+            TerraformResult(
+                0, b"Apply complete! Resources: 5 added, 0 changed, 0 destroyed.", b""
+            ),
         )
-        assert "apply" in h._board._seen_actions
+        row = board._build_thread_messages()[0][1]["rows"][1]
+        assert row[4] == {"type": "raw_text", "text": "5"}
+        assert row[5]["type"] == "raw_text"
 
-    def test_apply_not_included_when_not_requested(self):
-        h = self._make_handler()
-        h.setup("prod", self._defs(["vpc"]), "/tmp", self._opts(plan=True, apply=False))
-        assert "apply" not in h._board._seen_actions
+    def test_chunking(self):
+        board = make_board()
+        register(board, *[f"def{i}" for i in range(131)])
+        messages = board._build_thread_messages()
+        assert len(messages) == 1
+        assert len(messages[0][1]["rows"]) == 132  # header + 131 rows
 
-    def test_destroy_inferred_from_option(self):
-        h = self._make_handler()
-        h.setup("prod", self._defs(["vpc"]), "/tmp", self._opts(destroy=True))
-        assert "destroy" in h._board._seen_actions
+        register(board, *[f"extra{i}" for i in range(119)])  # 250 total
+        messages = board._build_thread_messages()
+        assert len(messages) == 2
+        assert len(messages[0][1]["rows"]) == 201
+        assert len(messages[1][0]["rows"]) == 51
+        assert "part 2/2" in messages[1][0]["caption"]
 
-    def test_posts_initial_board(self):
-        h = self._make_handler()
-        h.setup("prod", self._defs(["vpc"]), "/tmp", self._opts())
-        assert h._client.chat_postMessage.called
 
-    def test_slack_error_does_not_raise(self):
-        h = self._make_handler()
-        h._client.chat_postMessage.side_effect = Exception("down")
-        h.setup("prod", self._defs(["vpc"]), "/tmp", self._opts())
+class TestFallbackText:
+    def test_covers_each_state(self):
+        board = make_board(title="apps/qa")
+        register(board, "a", "b")
+        finish_ok(board, "a")
+        assert "Apply apps/qa: in progress — 1 of 2 finished" in board._fallback_text()
+        finish_ok(board, "b")
+        assert "complete — 2 definitions succeeded" in board._fallback_text()
+        fail_def(board, "b")
+        assert "failed — 1 of 2 definitions errored" in board._fallback_text()
 
-    def test_does_not_overwrite_existing_status(self):
-        """If execute() already marked a status, setup() must not reset it."""
-        h = self._make_handler()
-        h._board._statuses["vpc"] = {"init": "running"}
-        h._board._seen_actions = ["init"]
-        defs = MagicMock()
-        defs.values.return_value = [Definition(name="vpc", path="/tmp")]
-        h.setup("prod", defs, "/tmp", self._opts())
-        assert h._board._statuses["vpc"]["init"] == "running"
 
-    def test_plan_destroy_infers_plan_column(self):
-        h = self._make_handler()
-        h.setup(
-            "prod",
-            self._defs(["vpc"]),
-            "/tmp",
-            self._opts(plan=False, plan_destroy=True),
+class TestPostOrUpdate:
+    def test_posts_then_updates_in_place(self):
+        board = make_board()
+        register(board, "a")
+        client = make_client()
+        board.post_or_update(client)
+        # first flush posts the channel message and one threaded reply
+        assert client.chat_postMessage.call_count == 2
+        calls = client.chat_postMessage.call_args_list
+        assert "thread_ts" not in calls[0].kwargs
+        assert calls[1].kwargs["thread_ts"] == "111.222"
+        assert all(c.kwargs.get("text") for c in calls)
+
+        board.mark("a", TerraformAction.INIT, "running")
+        board.post_or_update(client)
+        assert client.chat_postMessage.call_count == 2
+        assert client.chat_update.called
+
+    def test_unchanged_state_skips_api_calls(self):
+        board = make_board()
+        register(board, "a")
+        client = make_client()
+        board.post_or_update(client)
+        board.post_or_update(client)
+        assert client.chat_postMessage.call_count == 2
+        assert client.chat_update.call_count == 0
+
+    def test_debounce_coalesces_and_force_bypasses(self):
+        board = make_board(update_interval=300.0)
+        register(board, "a")
+        client = make_client()
+        board.post_or_update(client, force=True)
+        board.mark("a", TerraformAction.INIT, "running")
+        board.post_or_update(client)
+        assert client.chat_update.call_count == 0
+        finish_ok(board, "a")
+        board.post_or_update(client, force=True)
+        assert client.chat_update.called
+
+    def test_no_post_without_definitions(self):
+        client = make_client()
+        make_board().post_or_update(client)
+        client.chat_postMessage.assert_not_called()
+
+    def test_slack_error_is_logged_not_raised(self):
+        board = make_board()
+        register(board, "a")
+        client = make_client()
+        client.chat_postMessage.side_effect = SlackApiError(
+            "boom", MagicMock(status_code=500)
         )
-        assert "plan" in h._board._seen_actions
+        board.post_or_update(client)  # must not raise
+
+    def test_rate_limited_update_is_dropped_and_deferred(self):
+        board = make_board()
+        register(board, "a")
+        client = make_client()
+        board.post_or_update(client)
+        board.mark("a", TerraformAction.INIT, "running")
+        resp = MagicMock(status_code=429)
+        resp.headers = {"Retry-After": "30"}
+        client.chat_update.side_effect = SlackApiError("ratelimited", resp)
+        board.post_or_update(client)  # must not raise
+        assert board._next_update_at > time.monotonic()
+
+    def test_forced_call_retries_on_rate_limit(self):
+        board = make_board()
+        register(board, "a")
+        client = make_client()
+        resp = MagicMock(status_code=429)
+        resp.headers = {"Retry-After": "1"}
+        client.chat_postMessage.side_effect = [
+            SlackApiError("ratelimited", resp),
+            {"ts": "111.222", "channel": "C123"},
+            {"ts": "111.333", "channel": "C123"},
+        ]
+        with patch("tfworker.handlers.slack.time.sleep") as sleep:
+            board.post_or_update(client, force=True)
+        assert board._ts == "111.222"
+        sleep.assert_called()
 
 
-class TestSlackHandlerTeardown:
-    def _make_handler(self):
-        from tfworker.handlers.slack import SlackConfig, SlackHandler
+def make_handler(**cfg_kwargs):
+    from tfworker.handlers.slack import SlackHandler
 
-        cfg = SlackConfig(channel="#ops", token="xoxb-test")
-        with patch("tfworker.handlers.slack.WebClient"):
-            h = SlackHandler(cfg)
-        h._client = MagicMock()
-        h._client.chat_postMessage.return_value = {"ts": "1.2", "channel": "C1"}
-        h._client.chat_update.return_value = {}
-        # Simulate that setup() already posted the parent + one threaded detail
-        # message, so teardown updates them in place rather than posting anew.
-        h._board._detail_ts = ["1.2"]
-        return h
+    handler = SlackHandler(make_config(**cfg_kwargs))
+    handler._client = make_client()
+    return handler
 
-    def test_teardown_posts_final_update(self):
-        h = self._make_handler()
-        h._board.ensure_definition("vpc", "prod", "/tmp")
-        h._board.mark("vpc", TerraformAction.PLAN, "done")
-        h._board._ts = "1.2"
-        h.teardown("prod", "/tmp")
-        assert h._client.chat_update.called
 
-    def test_teardown_fixes_stuck_running(self):
-        """PRE fired but plan was skipped — teardown marks it skipped, not failed.
+def make_definition(name: str, always_apply: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(name=name, always_apply=always_apply)
 
-        A genuine terraform failure calls ctx.exit(1) which raises SystemExit,
-        so teardown is never reached for real failures.
-        """
-        h = self._make_handler()
-        h._board.ensure_definition("vpc", "prod", "/tmp")
-        h._board._statuses["vpc"]["plan"] = "running"
-        h._board._seen_actions = ["plan"]
-        h._board._ts = "1.2"
-        h.teardown("prod", "/tmp")
-        assert h._board._statuses["vpc"]["plan"] == "skipped"
 
-    def test_teardown_no_extra_messages(self):
-        """teardown only updates the board — no additional postMessage calls."""
-        h = self._make_handler()
-        h._board.ensure_definition("vpc", "prod", "/tmp")
-        h._board.mark("vpc", TerraformAction.PLAN, "done")
-        h._board._ts = "1.2"
-        h.teardown("prod", "/tmp")
-        h._client.chat_postMessage.assert_not_called()
+def make_options(**kwargs) -> SimpleNamespace:
+    defaults = {"plan": True, "apply": False, "destroy": False, "plan_destroy": False}
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
 
-    def test_teardown_marks_pending_as_skipped(self):
-        """Actions pre-populated by setup() but never started are shown as skipped."""
-        h = self._make_handler()
-        h._board.ensure_definition("vpc", "prod", "/tmp")
-        h._board._statuses["vpc"]["plan"] = "done"
-        h._board._statuses["vpc"]["apply"] = "pending"
-        h._board._seen_actions = ["plan", "apply"]
-        h._board._ts = "1.2"
-        h.teardown("prod", "/tmp")
-        assert h._board._statuses["vpc"]["apply"] == "skipped"
 
-    def test_teardown_slack_error_does_not_raise(self):
-        h = self._make_handler()
-        h._client.chat_update.side_effect = Exception("down")
-        h._board._ts = "1.2"
-        h.teardown("prod", "/tmp")
+class TestSlackHandler:
+    def test_registered_and_ready(self):
+        from tfworker.handlers.registry import HandlerRegistry
+        from tfworker.handlers.slack import SlackHandler
+
+        assert HandlerRegistry.get_handlers()["slack"] is SlackHandler
+        assert SlackHandler.config_model is SlackConfig
+        handler = make_handler()
+        assert handler.is_ready() is True
+        # outside a click context, root options fall back to defaults
+        assert handler._board._run_id is None
+        assert handler._board._backend_plans is False
+
+    def test_setup_registers_definitions_and_infers_actions(self):
+        handler = make_handler()
+        definitions = {n: make_definition(n) for n in ("d1", "d2")}
+        handler.setup("apps-qa", definitions, "/tmp", make_options(apply=True))
+        assert set(handler._board._records) == {"d1", "d2"}
+        assert handler._board._expected_actions == ["init", "plan", "apply"]
+        assert handler._board._primary_action == "apply"
+        assert handler._client.chat_postMessage.call_count == 2  # main + thread
+
+    @pytest.mark.parametrize(
+        "options,definition,expected",
+        [
+            ({}, make_definition("d"), ["init", "plan"]),
+            ({}, make_definition("d", always_apply=True), ["init", "plan", "apply"]),
+            (
+                {"plan": False, "destroy": True},
+                make_definition("d"),
+                ["init", "destroy"],
+            ),
+            (
+                {"plan": False, "plan_destroy": True},
+                make_definition("d"),
+                ["init", "plan"],
+            ),
+        ],
+    )
+    def test_setup_expected_action_inference(self, options, definition, expected):
+        handler = make_handler()
+        handler.setup("apps-qa", {"d": definition}, "/tmp", make_options(**options))
+        assert handler._board._expected_actions == expected
+
+    @pytest.mark.parametrize(
+        "action,result,expected_status",
+        [
+            (TerraformAction.INIT, TerraformResult(0, b"", b""), "done"),
+            (TerraformAction.APPLY, None, "failed"),
+            (TerraformAction.PLAN, TerraformResult(2, b"", b""), "changes"),
+            (TerraformAction.APPLY, TerraformResult(2, b"", b""), "failed"),
+        ],
+    )
+    def test_execute_post_status_mapping(self, action, result, expected_status):
+        handler = make_handler()
+        handler.setup(
+            "apps-qa", {"d1": make_definition("d1")}, "/tmp", make_options(apply=True)
+        )
+        handler.execute(
+            action,
+            TerraformStage.POST,
+            "apps-qa",
+            make_definition("d1"),
+            "/tmp",
+            result=result,
+        )
+        assert handler._board._records["d1"].statuses[action.value] == expected_status
+
+    def test_execute_pre_marks_running(self):
+        handler = make_handler()
+        handler.setup(
+            "apps-qa", {"d1": make_definition("d1")}, "/tmp", make_options(apply=True)
+        )
+        handler.execute(
+            TerraformAction.INIT,
+            TerraformStage.PRE,
+            "apps-qa",
+            make_definition("d1"),
+            "/tmp",
+        )
+        assert handler._board._records["d1"].statuses["init"] == "running"
+
+    def test_clean_plan_marks_apply_skipped(self):
+        handler = make_handler()
+        handler.setup(
+            "apps-qa", {"d1": make_definition("d1")}, "/tmp", make_options(apply=True)
+        )
+        handler.execute(
+            TerraformAction.PLAN,
+            TerraformStage.POST,
+            "apps-qa",
+            make_definition("d1"),
+            "/tmp",
+            result=TerraformResult(0, b"No changes.", b""),
+        )
+        rec = handler._board._records["d1"]
+        assert rec.statuses["plan"] == "done"
+        assert rec.statuses["apply"] == "skipped"
+
+    def test_error_stage_records_snippet(self):
+        handler = make_handler()
+        handler.setup(
+            "apps-qa", {"d1": make_definition("d1")}, "/tmp", make_options(apply=True)
+        )
+        handler.execute(
+            TerraformAction.APPLY,
+            TerraformStage.ERROR,
+            "apps-qa",
+            make_definition("d1"),
+            "/tmp",
+            result=TerraformResult(1, b"", b"Error: AccessDenied on sts:AssumeRole"),
+        )
+        rec = handler._board._records["d1"]
+        assert rec.statuses["apply"] == "failed"
+        assert "AccessDenied" in rec.error_snippet
+
+    def test_teardown_marks_unfinished_as_skipped_and_flushes(self):
+        handler = make_handler()
+        handler.setup(
+            "apps-qa",
+            {n: make_definition(n) for n in ("d1", "d2")},
+            "/tmp",
+            make_options(apply=True),
+        )
+        handler.execute(
+            TerraformAction.INIT,
+            TerraformStage.PRE,
+            "apps-qa",
+            make_definition("d1"),
+            "/tmp",
+        )
+        handler.teardown("apps-qa", "/tmp")
+        board = handler._board
+        assert board._records["d1"].statuses["init"] == "skipped"
+        assert board._records["d2"].statuses["plan"] == "skipped"
+        assert board.is_terminal() is True
+        assert handler._client.chat_update.called
+
+    def test_slack_failures_never_raise(self):
+        handler = make_handler()
+        handler._client.chat_postMessage.side_effect = Exception("boom")
+        handler._client.chat_update.side_effect = Exception("boom")
+        handler.setup("apps-qa", {"d": make_definition("d")}, "/tmp", make_options())
+        handler.execute(
+            TerraformAction.INIT,
+            TerraformStage.PRE,
+            "apps-qa",
+            make_definition("d"),
+            "/tmp",
+        )
+        handler.teardown("apps-qa", "/tmp")

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -338,13 +338,14 @@ class TestMainBlocks:
 
 
 class TestPlanBlock:
-    def test_fresh_block_id_per_update(self):
+    def test_stable_block_id_across_updates(self):
+        # a fresh block_id per update would reset the block's
+        # expanded/collapsed state under a watching user
         board = make_board()
         register(board, "a")
-        board._seq = 1
         first = board._build_main_blocks()[1]["block_id"]
-        board._seq = 2
-        assert first != board._build_main_blocks()[1]["block_id"]
+        board.mark("a", TerraformAction.INIT, "running")
+        assert board._build_main_blocks()[1]["block_id"] == first
 
     def test_error_cards_capped_with_datadog_sources(self):
         # the literal braces in the template must not raise (str.format would)
@@ -375,10 +376,24 @@ class TestPlanBlock:
         named = [t for t in plan["tasks"] if t["task_id"].startswith("run_")]
         assert len(named) == board.MAX_NAMED_RUNNING
         assert named[0]["task_id"] == "run_def3"
+        # verbs follow the action actually running (init here), not the
+        # run's primary verb ("applying")
+        assert named[0]["title"].endswith("— initializing")
         rollup = next(t for t in plan["tasks"] if t["task_id"] == "rollup_running")
-        assert "3 more" in rollup["title"]
+        assert "3 more initializing" in rollup["title"]
         queued = next(t for t in plan["tasks"] if t["task_id"] == "rollup_queued")
         assert "1 definitions queued" in queued["title"]
+
+    def test_running_verb_follows_actual_action(self):
+        board = make_board()
+        register(board, "a", "b")
+        board.mark("a", TerraformAction.INIT, "running")
+        status = board._build_main_blocks()[0]["child_blocks"][0]["text"]["text"]
+        assert "*Initializing*" in status
+        board.mark("a", TerraformAction.INIT, "done")
+        board.mark("a", TerraformAction.APPLY, "running")
+        status = board._build_main_blocks()[0]["child_blocks"][0]["text"]["text"]
+        assert "*Applying*" in status
 
     def test_running_task_shows_plan_line(self):
         board = make_board()

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -208,6 +208,17 @@ class TestResultParsing:
         board.record_result("vpc", TerraformAction.APPLY, None, failed=True)
         assert board._records["vpc"].error_snippet is None
 
+    def test_non_utf8_output_does_not_raise(self):
+        board = make_board()
+        register(board, "vpc")
+        board.record_result(
+            "vpc",
+            TerraformAction.APPLY,
+            TerraformResult(1, b"\xff\xfe bad bytes", b"Error: broken \xff"),
+            failed=True,
+        )
+        assert "broken" in board._records["vpc"].error_snippet
+
 
 class TestGitContext:
     def test_ci_env_vars(self):
@@ -284,7 +295,7 @@ class TestMainBlocks:
         assert "has_header_divider" not in container
         assert "finished in" in container["subtitle"]["text"]
         verdict = container["child_blocks"][0]["text"]["text"]
-        assert "Run complete — 2 definitions succeeded" in verdict
+        assert "Run complete — 1 applied, 1 skipped" in verdict
 
         assert all(t["status"] == "complete" for t in plan["tasks"])
         skipped = next(t for t in plan["tasks"] if t["task_id"] == "rollup_skipped")
@@ -322,8 +333,9 @@ class TestPlanBlock:
         assert first != board._build_main_blocks()[1]["block_id"]
 
     def test_error_cards_capped_with_datadog_sources(self):
+        # the literal braces in the template must not raise (str.format would)
         board = make_board(
-            definition_log_url_template="https://dd.example/logs?q={definition}"
+            definition_log_url_template='https://dd.example/logs?q={"svc"}&def={definition}'
         )
         register(board, *[f"def{i}" for i in range(10)])
         for i in range(8):
@@ -333,7 +345,10 @@ class TestPlanBlock:
         plan = board._build_main_blocks()[1]
         errors = [t for t in plan["tasks"] if t["status"] == "error"]
         assert len(errors) == board.MAX_ERROR_CARDS
-        assert errors[0]["sources"][0]["url"] == "https://dd.example/logs?q=def0"
+        assert (
+            errors[0]["sources"][0]["url"]
+            == 'https://dd.example/logs?q={"svc"}&def=def0'
+        )
 
     def test_running_tasks_named_oldest_first_then_rolled_up(self):
         board = make_board()
@@ -463,6 +478,19 @@ class TestThreadMessages:
         assert len(messages[1][0]["rows"]) == 51
         assert "part 2/2" in messages[1][0]["caption"]
 
+    def test_chunking_by_character_budget(self):
+        board = make_board()
+        register(board, *["x" * 400 + str(i) for i in range(100)])
+        messages = board._build_thread_messages()
+        # 100 rows fit the row limit but blow the 18k char budget
+        assert len(messages) > 1
+        for blocks in messages:
+            table = blocks[-1]
+            chars = sum(
+                board._cell_chars(cell) for row in table["rows"] for cell in row
+            )
+            assert chars <= board.MAX_DATA_TABLE_CHARS + 500  # header overhead
+
 
 class TestFallbackText:
     def test_covers_each_state(self):
@@ -471,7 +499,7 @@ class TestFallbackText:
         finish_ok(board, "a")
         assert "Apply apps/qa: in progress — 1 of 2 finished" in board._fallback_text()
         finish_ok(board, "b")
-        assert "complete — 2 definitions succeeded" in board._fallback_text()
+        assert "complete — 2 applied" in board._fallback_text()
         fail_def(board, "b")
         assert "failed — 1 of 2 definitions errored" in board._fallback_text()
 
@@ -515,19 +543,22 @@ class TestPostOrUpdate:
         board.post_or_update(client, force=True)
         assert client.chat_update.called
 
-    def test_no_post_without_definitions(self):
+    def test_zero_definition_run_still_posts(self):
         client = make_client()
-        make_board().post_or_update(client)
-        client.chat_postMessage.assert_not_called()
+        make_board().post_or_update(client, force=True)
+        client.chat_postMessage.assert_called_once()
 
-    def test_slack_error_is_logged_not_raised(self):
-        board = make_board()
+    def test_slack_error_is_logged_not_raised_and_debounced(self):
+        board = make_board(update_interval=300.0)
         register(board, "a")
         client = make_client()
         client.chat_postMessage.side_effect = SlackApiError(
             "boom", MagicMock(status_code=500)
         )
         board.post_or_update(client)  # must not raise
+        # a failed post must still engage the debounce, not retry per event
+        board.post_or_update(client)
+        assert client.chat_postMessage.call_count == 1
 
     def test_rate_limited_update_is_dropped_and_deferred(self):
         board = make_board()

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -108,16 +108,27 @@ class TestBoardState:
 
     def test_classification_buckets(self):
         board = make_board()
-        register(board, "queued", "running", "ok", "failed", "skipped")
+        register(board, "queued", "running", "ok", "no_changes", "failed", "skipped")
         board.mark("running", TerraformAction.INIT, "running")
         finish_ok(board, "ok")
+        finish_ok(board, "no_changes", changes=False)
         fail_def(board, "failed")
         for action in ("init", "plan", "apply"):
             board._records["skipped"].statuses[action] = "skipped"
 
         buckets = board._buckets()
-        for bucket in ("queued", "running", "ok", "failed", "skipped"):
+        for bucket in ("queued", "running", "ok", "no_changes", "failed", "skipped"):
             assert [r.name for r in buckets[bucket]] == [bucket]
+
+    def test_aborted_definition_is_skipped_not_no_changes(self):
+        # init ran but plan never did (aborted run resolved by teardown):
+        # the plan didn't find "no changes" — it didn't run
+        board = make_board()
+        register(board, "aborted")
+        board.mark("aborted", TerraformAction.INIT, "done")
+        board._records["aborted"].statuses["plan"] = "skipped"
+        board._records["aborted"].statuses["apply"] = "skipped"
+        assert board._classify(board._records["aborted"]) == "skipped"
 
     def test_overall_status_transitions(self):
         board = make_board()
@@ -295,11 +306,14 @@ class TestMainBlocks:
         assert "has_header_divider" not in container
         assert "finished in" in container["subtitle"]["text"]
         verdict = container["child_blocks"][0]["text"]["text"]
-        assert "Run complete — 1 applied, 1 skipped" in verdict
+        assert "Run complete — 1 applied, 1 no changes" in verdict
 
         assert all(t["status"] == "complete" for t in plan["tasks"])
-        skipped = next(t for t in plan["tasks"] if t["task_id"] == "rollup_skipped")
-        assert "1 definitions skipped" in skipped["title"]
+        no_changes = next(
+            t for t in plan["tasks"] if t["task_id"] == "rollup_no_changes"
+        )
+        assert "1 definitions with no changes" in no_changes["title"]
+        assert not any(t["task_id"] == "rollup_skipped" for t in plan["tasks"])
 
     def test_failed_final_layout(self):
         board = make_board()
@@ -439,7 +453,7 @@ class TestThreadMessages:
             "Plan",
             "Apply",
             "Changed",
-            "Secs",
+            "Ran (s)",
         ]
         row = table["rows"][1]
         assert rich_text(row[0]) == "vpc"

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -285,12 +285,10 @@ class TestMainBlocks:
         assert "is_collapsible" not in container
         subtitle = container["subtitle"]["text"]
         assert "run `1234`" in subtitle
-        # plain clocks in the configured timezone: the container subtitle
+        # plain clock in the configured timezone: the container subtitle
         # renders Slack's <!date> command literally rather than processing it
         assert "<!date" not in subtitle
-        assert re.search(
-            r"started \d\d:\d\d C[DS]T · updated \d\d:\d\d C[DS]T", subtitle
-        )
+        assert re.search(r"started \d\d:\d\d C[DS]T", subtitle)
 
         status, counts, links = container["child_blocks"]
         assert "*Applying*" in status["text"]["text"]
@@ -302,6 +300,9 @@ class TestMainBlocks:
         assert "*2* running" in counts_text
         assert "*128* queued" in counts_text
         assert "<https://argo.example/wf|Argo workflow>" in links["elements"][0]["text"]
+        # live relative timestamp in the links context (which renders <!date>)
+        updated = links["elements"][1]["text"]
+        assert re.search(r"updated <!date\^\d+\^\{ago\}\|\d\d:\d\d C[DS]T>", updated)
 
     def test_success_final_layout(self):
         board = make_board()

--- a/tests/handlers/test_slack_handler.py
+++ b/tests/handlers/test_slack_handler.py
@@ -234,7 +234,9 @@ class TestSlackStatusBoardGitContext:
         assert result is None
 
 
-class TestSlackStatusBoardBlocks:
+class TestSlackStatusBoardSummary:
+    """The compact parent message: header, git context, banner, counts."""
+
     def _make_board(self, title=None, run_id=None):
         from tfworker.handlers.slack import SlackStatusBoard
 
@@ -242,176 +244,178 @@ class TestSlackStatusBoardBlocks:
         b._deployment = "prod"
         return b
 
-    def test_blocks_is_list(self):
+    def test_summary_is_list(self):
         board = self._make_board()
         board.ensure_definition("vpc", "prod", "/tmp")
         board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
+        blocks = board._build_summary_blocks()
         assert isinstance(blocks, list)
         assert len(blocks) >= 1
 
     def test_header_block_contains_deployment(self):
         board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        header = blocks[0]
+        header = board._build_summary_blocks()[0]
         assert header["type"] == "header"
         assert "prod" in header["text"]["text"]
 
     def test_header_uses_title_when_set(self):
         board = self._make_board(title="My Run")
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        assert "My Run" in blocks[0]["text"]["text"]
+        assert "My Run" in board._build_summary_blocks()[0]["text"]["text"]
 
     def test_header_includes_run_id(self):
         board = self._make_board(run_id="run-42")
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        assert "run-42" in blocks[0]["text"]["text"]
+        assert "run-42" in board._build_summary_blocks()[0]["text"]["text"]
 
-    def test_git_context_block_present_when_available(self):
+    def test_git_context_present_when_available(self):
         board = self._make_board()
         board._git_context = "Branch: main  Commit: abc1234"
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        context_texts = [str(b) for b in blocks if b.get("type") == "context"]
-        assert any("main" in t for t in context_texts)
-
-    def test_status_table_contains_definition_name(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        all_text = str(blocks)
-        assert "vpc" in all_text
-
-    def test_status_table_contains_action_column(self):
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        all_text = str(blocks)
-        assert "Plan" in all_text or "plan" in all_text
+        blocks = board._build_summary_blocks()
+        assert any(b.get("type") == "context" and "main" in str(b) for b in blocks)
 
     def test_banner_in_progress(self):
         board = self._make_board()
         board.ensure_definition("vpc", "prod", "/tmp")
         board.mark("vpc", TerraformAction.PLAN, "running")
-        blocks = board._build_blocks()
-        all_text = str(blocks)
-        assert "🟡" in all_text
+        assert "🟡" in str(board._build_summary_blocks())
 
     def test_banner_done(self):
         board = self._make_board()
         board.ensure_definition("vpc", "prod", "/tmp")
         board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        all_text = str(blocks)
-        assert "✅" in all_text
+        assert "✅" in str(board._build_summary_blocks())
 
     def test_banner_failed(self):
         board = self._make_board()
         board.ensure_definition("vpc", "prod", "/tmp")
         board.mark("vpc", TerraformAction.PLAN, "failed")
-        blocks = board._build_blocks()
-        all_text = str(blocks)
-        assert "❌" in all_text
+        assert "❌" in str(board._build_summary_blocks())
 
     def test_banner_done_with_skips(self):
         board = self._make_board()
         board.ensure_definition("vpc", "prod", "/tmp")
         board.mark("vpc", TerraformAction.INIT, "done")
         board.mark("vpc", TerraformAction.PLAN, "skipped")
-        blocks = board._build_blocks()
-        all_text = str(blocks)
-        assert "✅" in all_text
-        assert "skipped" in all_text
+        text = str(board._build_summary_blocks())
+        assert "✅" in text
+        assert "skipped" in text
 
     def test_banner_done_no_skips(self):
         board = self._make_board()
         board.ensure_definition("vpc", "prod", "/tmp")
         board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        all_text = str(blocks)
-        assert "succeeded" in all_text
-        assert "skipped" not in all_text
+        assert "succeeded" in str(board._build_summary_blocks())
 
-    def test_only_observed_actions_as_columns(self):
-        """A plan-only run shows Init and Plan columns only."""
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.INIT, "done")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        all_text = str(blocks)
-        assert "Apply" not in all_text
-        assert "Destroy" not in all_text
-
-    def test_status_table_uses_fields_layout(self):
-        """Table rows are rendered as section blocks with fields, not tab-separated text."""
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        fields_sections = [
-            b for b in blocks if b.get("type") == "section" and "fields" in b
-        ]
-        assert len(fields_sections) >= 2  # header row + at least one definition row
-
-    def test_status_table_header_fields_structure(self):
-        """Header row has exactly 2 fields: Definition label and action labels."""
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        fields_sections = [
-            b for b in blocks if b.get("type") == "section" and "fields" in b
-        ]
-        header = fields_sections[0]
-        assert len(header["fields"]) == 2
-        assert header["fields"][0]["text"] == "*Definition*"
-        assert "*Plan*" in header["fields"][1]["text"]
-
-    def test_status_table_definition_row_structure(self):
-        """Definition rows have name on left, emoji string on right."""
-        board = self._make_board()
-        board.ensure_definition("vpc", "prod", "/tmp")
-        board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        fields_sections = [
-            b for b in blocks if b.get("type") == "section" and "fields" in b
-        ]
-        def_row = fields_sections[1]
-        assert len(def_row["fields"]) == 2
-        assert "`vpc`" in def_row["fields"][0]["text"]
-        assert "✅" in def_row["fields"][1]["text"]
-
-    def test_multiple_definitions_produce_multiple_rows(self):
-        """Multiple definitions produce one section+fields block each."""
+    def test_summary_includes_definition_count(self):
         board = self._make_board()
         for name in ["vpc", "eks", "rds"]:
             board.ensure_definition(name, "prod", "/tmp")
             board.mark(name, TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        fields_sections = [
-            b for b in blocks if b.get("type") == "section" and "fields" in b
-        ]
-        assert len(fields_sections) == 4  # 1 header + 3 definition rows
+        assert "3" in str(board._build_summary_blocks())
 
-    def test_table_section_blocks_have_no_text_key(self):
-        """Table section blocks use 'fields', not a top-level 'text' key."""
+    def test_summary_points_to_thread(self):
         board = self._make_board()
         board.ensure_definition("vpc", "prod", "/tmp")
         board.mark("vpc", TerraformAction.PLAN, "done")
-        blocks = board._build_blocks()
-        for block in blocks:
+        assert "thread" in str(board._build_summary_blocks()).lower()
+
+
+class TestSlackStatusBoardDetail:
+    """The threaded per-definition table, chunked under Slack's block limit."""
+
+    def _make_board(self, title=None, run_id=None):
+        from tfworker.handlers.slack import SlackStatusBoard
+
+        b = SlackStatusBoard(channel="#ops", title=title, run_id=run_id)
+        b._deployment = "prod"
+        return b
+
+    def test_detail_contains_definition_name(self):
+        board = self._make_board()
+        board.ensure_definition("vpc", "prod", "/tmp")
+        board.mark("vpc", TerraformAction.PLAN, "done")
+        assert "vpc" in str(board._build_detail_chunks())
+
+    def test_detail_contains_action_column(self):
+        board = self._make_board()
+        board.ensure_definition("vpc", "prod", "/tmp")
+        board.mark("vpc", TerraformAction.PLAN, "done")
+        assert "Plan" in str(board._build_detail_chunks())
+
+    def test_only_observed_actions_as_columns(self):
+        board = self._make_board()
+        board.ensure_definition("vpc", "prod", "/tmp")
+        board.mark("vpc", TerraformAction.INIT, "done")
+        board.mark("vpc", TerraformAction.PLAN, "done")
+        text = str(board._build_detail_chunks())
+        assert "Apply" not in text
+        assert "Destroy" not in text
+
+    def test_chunk_uses_fields_layout(self):
+        board = self._make_board()
+        board.ensure_definition("vpc", "prod", "/tmp")
+        board.mark("vpc", TerraformAction.PLAN, "done")
+        chunk = board._build_detail_chunks()[0]
+        fields_sections = [
+            b for b in chunk if b.get("type") == "section" and "fields" in b
+        ]
+        assert len(fields_sections) >= 2  # header row + at least one definition row
+
+    def test_chunk_header_fields_structure(self):
+        board = self._make_board()
+        board.ensure_definition("vpc", "prod", "/tmp")
+        board.mark("vpc", TerraformAction.PLAN, "done")
+        chunk = board._build_detail_chunks()[0]
+        header = [b for b in chunk if b.get("type") == "section" and "fields" in b][0]
+        assert len(header["fields"]) == 2
+        assert header["fields"][0]["text"] == "*Definition*"
+        assert "*Plan*" in header["fields"][1]["text"]
+
+    def test_chunk_definition_row_structure(self):
+        board = self._make_board()
+        board.ensure_definition("vpc", "prod", "/tmp")
+        board.mark("vpc", TerraformAction.PLAN, "done")
+        chunk = board._build_detail_chunks()[0]
+        rows = [b for b in chunk if b.get("type") == "section" and "fields" in b]
+        def_row = rows[1]
+        assert "`vpc`" in def_row["fields"][0]["text"]
+        assert "✅" in def_row["fields"][1]["text"]
+
+    def test_multiple_definitions_one_chunk(self):
+        board = self._make_board()
+        for name in ["vpc", "eks", "rds"]:
+            board.ensure_definition(name, "prod", "/tmp")
+            board.mark(name, TerraformAction.PLAN, "done")
+        chunks = board._build_detail_chunks()
+        assert len(chunks) == 1
+        rows = [
+            b for b in chunks[0] if b.get("type") == "section" and "fields" in b
+        ]
+        assert len(rows) == 4  # 1 header + 3 definition rows
+
+    def test_row_section_blocks_have_no_text_key(self):
+        board = self._make_board()
+        board.ensure_definition("vpc", "prod", "/tmp")
+        board.mark("vpc", TerraformAction.PLAN, "done")
+        for block in board._build_detail_chunks()[0]:
             if block.get("type") == "section" and "fields" in block:
                 assert "text" not in block
+
+    def test_large_board_splits_under_block_limit(self):
+        """Many definitions split into multiple messages, each under Slack's limit."""
+        board = self._make_board()
+        for i in range(60):
+            name = f"svc_{i:02d}"
+            board.ensure_definition(name, "prod", "/tmp")
+            board.mark(name, TerraformAction.INIT, "pending")
+            board.mark(name, TerraformAction.PLAN, "pending")
+        chunks = board._build_detail_chunks()
+        assert len(chunks) == 2  # ceil(60 / DETAIL_ROWS_PER_MSG=45)
+        for chunk in chunks:
+            assert len(chunk) <= board.MAX_BLOCKS
+
+    def test_no_chunks_when_no_actions(self):
+        board = self._make_board()
+        assert board._build_detail_chunks() == []
 
 
 class TestSlackStatusBoardPostOrUpdate:
@@ -429,12 +433,16 @@ class TestSlackStatusBoardPostOrUpdate:
         client.chat_postMessage.return_value = {"ts": "111.222", "channel": "C123"}
         return client
 
-    def test_first_call_uses_post_message(self):
+    def test_first_call_posts_parent_and_thread(self):
         board = self._make_board()
         client = self._mock_client()
         board.post_or_update(client)
-        client.chat_postMessage.assert_called_once()
+        # parent summary message + one threaded detail message
+        assert client.chat_postMessage.call_count == 2
         client.chat_update.assert_not_called()
+        first, second = client.chat_postMessage.call_args_list
+        assert first.kwargs.get("thread_ts") is None  # parent (thread root)
+        assert second.kwargs.get("thread_ts") == "111.222"  # threaded detail
 
     def test_first_call_stores_ts(self):
         board = self._make_board()
@@ -448,15 +456,25 @@ class TestSlackStatusBoardPostOrUpdate:
         board.post_or_update(client)
         board.mark("vpc", TerraformAction.PLAN, "done")
         board.post_or_update(client)
-        client.chat_update.assert_called_once()
+        # both the parent summary and the changed detail chunk are updated
+        assert client.chat_update.called
+
+    def test_unchanged_second_call_is_noop(self):
+        board = self._make_board()
+        client = self._mock_client()
+        board.post_or_update(client)
+        board.post_or_update(client)  # nothing changed
+        client.chat_update.assert_not_called()
 
     def test_update_uses_stored_ts(self):
         board = self._make_board()
         client = self._mock_client()
         board.post_or_update(client)
+        board.mark("vpc", TerraformAction.PLAN, "done")
         board.post_or_update(client)
-        call_kwargs = client.chat_update.call_args.kwargs
-        assert call_kwargs["ts"] == "111.222"
+        assert client.chat_update.called
+        for call in client.chat_update.call_args_list:
+            assert call.kwargs["ts"] == "111.222"
 
     def test_slack_error_is_logged_not_raised(self):
         board = self._make_board()
@@ -528,7 +546,7 @@ class TestSlackHandlerExecute:
         defn = self._make_definition()
         handler.execute(TerraformAction.PLAN, TerraformStage.PRE, "prod", defn, "/tmp")
         assert handler._board._statuses["vpc"]["plan"] == "running"
-        handler._client.chat_postMessage.assert_called_once()
+        assert handler._client.chat_postMessage.called
 
     def test_post_success_marks_done_and_updates(self):
         handler = self._make_handler()
@@ -539,7 +557,7 @@ class TestSlackHandlerExecute:
             TerraformAction.PLAN, TerraformStage.POST, "prod", defn, "/tmp", result
         )
         assert handler._board._statuses["vpc"]["plan"] == "done"
-        handler._client.chat_update.assert_called_once()
+        assert handler._client.chat_update.called
 
     def test_post_failure_marks_failed_and_updates(self):
         handler = self._make_handler()
@@ -560,7 +578,7 @@ class TestSlackHandlerExecute:
             TerraformAction.APPLY, TerraformStage.ERROR, "prod", defn, "/tmp", result
         )
         assert handler._board._statuses["vpc"]["apply"] == "failed"
-        handler._client.chat_update.assert_called_once()
+        assert handler._client.chat_update.called
 
     def test_multiple_definitions_tracked(self):
         handler = self._make_handler()
@@ -735,7 +753,7 @@ class TestSlackHandlerSetup:
     def test_posts_initial_board(self):
         h = self._make_handler()
         h.setup("prod", self._defs(["vpc"]), "/tmp", self._opts())
-        h._client.chat_postMessage.assert_called_once()
+        assert h._client.chat_postMessage.called
 
     def test_slack_error_does_not_raise(self):
         h = self._make_handler()
@@ -773,6 +791,9 @@ class TestSlackHandlerTeardown:
         h._client = MagicMock()
         h._client.chat_postMessage.return_value = {"ts": "1.2", "channel": "C1"}
         h._client.chat_update.return_value = {}
+        # Simulate that setup() already posted the parent + one threaded detail
+        # message, so teardown updates them in place rather than posting anew.
+        h._board._detail_ts = ["1.2"]
         return h
 
     def test_teardown_posts_final_update(self):
@@ -781,7 +802,7 @@ class TestSlackHandlerTeardown:
         h._board.mark("vpc", TerraformAction.PLAN, "done")
         h._board._ts = "1.2"
         h.teardown("prod", "/tmp")
-        h._client.chat_update.assert_called_once()
+        assert h._client.chat_update.called
 
     def test_teardown_fixes_stuck_running(self):
         """PRE fired but plan was skipped — teardown marks it skipped, not failed.

--- a/tests/handlers/test_slack_live.py
+++ b/tests/handlers/test_slack_live.py
@@ -1,0 +1,211 @@
+"""Live Slack integration tests for the slack handler.
+
+These exercise every payload shape the handler produces against the real
+Slack API (post, update, delete) — ``blocks.validate`` is known to accept
+payloads the message APIs reject, so only real calls prove the layout.
+
+Skipped unless SLACK_LIVE_TEST=1 and SLACK_BOT_TOKEN are set. Messages are
+posted to SLACK_TEST_CHANNEL (default #neptune_testing) and deleted after
+each test. Run with::
+
+    SLACK_LIVE_TEST=1 SLACK_BOT_TOKEN=xoxb-... poetry run pytest \
+        tests/handlers/test_slack_live.py -v
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tfworker.commands.terraform import TerraformResult
+from tfworker.custom_types.terraform import TerraformAction
+from tfworker.handlers.slack import SlackConfig, SlackStatusBoard
+
+LIVE = os.environ.get("SLACK_LIVE_TEST") == "1" and bool(
+    os.environ.get("SLACK_BOT_TOKEN")
+)
+CHANNEL = os.environ.get("SLACK_TEST_CHANNEL", "C0BLQQNMN49")  # #neptune_testing
+
+pytestmark = pytest.mark.skipif(
+    not LIVE, reason="live Slack test; set SLACK_LIVE_TEST=1 and SLACK_BOT_TOKEN"
+)
+
+APPLY_OK = b"Apply complete! Resources: 3 added, 1 changed, 0 destroyed."
+PLAN_CHANGES = b"Plan: 3 to add, 1 to change, 0 to destroy."
+PLAN_CLEAN = b"No changes. Infrastructure is up-to-date."
+APPLY_ERROR = (
+    b"Error: creating EventBus: AccessDenied - not authorized to perform "
+    b"sts:AssumeRole on NeptuneExecutor"
+)
+
+
+@pytest.fixture
+def client():
+    from slack_sdk import WebClient
+
+    return WebClient(token=os.environ["SLACK_BOT_TOKEN"])
+
+
+@pytest.fixture
+def slack_errors():
+    """Capture handler-swallowed Slack errors so tests can assert none occurred."""
+    with patch("tfworker.handlers.slack.log.error") as mock_error:
+        yield mock_error
+
+
+def make_board(run_id: str, **cfg) -> SlackStatusBoard:
+    cfg.setdefault("title", "apps/qa (live test)")
+    cfg.setdefault("update_interval", 0.0)
+    cfg.setdefault(
+        "links",
+        [
+            {"text": "Argo workflow", "url": "https://argo.example/workflows/ops/wf-1"},
+            {
+                "text": "logs",
+                "url": "https://app.datadoghq.com/logs?query=service%3Aneptune-executor",
+            },
+        ],
+    )
+    cfg.setdefault(
+        "definition_log_url_template",
+        "https://app.datadoghq.com/logs?query=service%3Aneptune-executor%20%40definition%3A{definition}",
+    )
+    config = SlackConfig(channel=CHANNEL, token=os.environ["SLACK_BOT_TOKEN"], **cfg)
+    return SlackStatusBoard(config=config, run_id=run_id, backend_plans=True)
+
+
+def register(board: SlackStatusBoard, names: list[str], apply: bool = True) -> None:
+    actions = [TerraformAction.INIT, TerraformAction.PLAN]
+    if apply:
+        actions.append(TerraformAction.APPLY)
+    board.set_expected_actions(actions)
+    for name in names:
+        board.ensure_definition(name, "apps-qa", "/tmp")
+
+
+def cleanup(client, board: SlackStatusBoard) -> None:
+    for ts in [board._ts, *board._thread_ts]:
+        if ts:
+            client.chat_delete(channel=board._channel, ts=ts)
+
+
+def assert_no_slack_errors(mock_error) -> None:
+    errors = [str(c.args[0]) for c in mock_error.call_args_list]
+    assert not errors, f"handler logged Slack errors: {errors}"
+
+
+def test_success_lifecycle_131_definitions(client, slack_errors):
+    """131 definitions: post → progress updates → success final, 2 messages total."""
+    names = [f"defn_{i:03d}" for i in range(131)]
+    board = make_board("live-success", update_interval=1.0)
+    register(board, names)
+    try:
+        # initial post: in-progress container + queued rollup, thread table
+        board.post_or_update(client, force=True)
+        assert board._ts is not None
+        assert len(board._thread_ts) == 1
+
+        # mid-run: some finished, some running (named + rollup), some queued
+        for name in names[:100]:
+            board.mark(name, TerraformAction.INIT, "done")
+            board.mark(name, TerraformAction.PLAN, "changes")
+            board.record_result(
+                name, TerraformAction.PLAN, TerraformResult(2, PLAN_CHANGES, b"")
+            )
+            board.mark(name, TerraformAction.APPLY, "done")
+            board.record_result(
+                name, TerraformAction.APPLY, TerraformResult(0, APPLY_OK, b"")
+            )
+        for name in names[100:106]:
+            board.mark(name, TerraformAction.INIT, "done")
+            board.mark(name, TerraformAction.PLAN, "changes")
+            board.mark(name, TerraformAction.APPLY, "running")
+        board.post_or_update(client, force=True)
+
+        # final: everything done, two clean-plan skips
+        for name in names[100:129]:
+            board.mark(name, TerraformAction.INIT, "done")
+            board.mark(name, TerraformAction.PLAN, "changes")
+            board.mark(name, TerraformAction.APPLY, "done")
+        for name in names[129:]:
+            board.mark(name, TerraformAction.INIT, "done")
+            board.record_result(
+                name, TerraformAction.PLAN, TerraformResult(0, PLAN_CLEAN, b"")
+            )
+            board.mark(name, TerraformAction.PLAN, "done")
+            board.mark(name, TerraformAction.APPLY, "skipped")
+        board.post_or_update(client, force=True)
+
+        assert board.overall_status() == "done"
+        # the whole run produced exactly two Slack messages
+        assert len(board._thread_ts) == 1
+        assert_no_slack_errors(slack_errors)
+    finally:
+        cleanup(client, board)
+
+
+def test_failed_lifecycle_with_overflow_failures(client, slack_errors):
+    """8 failures: error cards cap at 5 mid-run, failed final shows table + remainder."""
+    names = [f"defn_{i:02d}" for i in range(20)]
+    board = make_board("live-failed")
+    register(board, names)
+    try:
+        board.post_or_update(client, force=True)
+
+        # 8 plan failures with real error snippets, some successes, one running
+        for name in names[:8]:
+            board.mark(name, TerraformAction.INIT, "done")
+            board.mark(name, TerraformAction.PLAN, "failed")
+            board.record_result(
+                name,
+                TerraformAction.PLAN,
+                TerraformResult(1, b"", APPLY_ERROR),
+                failed=True,
+            )
+        for name in names[8:14]:
+            board.mark(name, TerraformAction.INIT, "done")
+            board.mark(name, TerraformAction.PLAN, "changes")
+            board.mark(name, TerraformAction.APPLY, "done")
+            board.record_result(
+                name, TerraformAction.APPLY, TerraformResult(0, APPLY_OK, b"")
+            )
+        board.mark(names[14], TerraformAction.INIT, "running")
+        board.post_or_update(client, force=True)  # in-progress with error cards
+
+        # teardown behavior: unfinished becomes skipped, final failed state
+        for rec in board._records.values():
+            for action in board._expected_actions:
+                if rec.statuses.get(action, "pending") in ("pending", "running"):
+                    rec.statuses[action] = "skipped"
+        board.post_or_update(client, force=True)
+
+        assert board.overall_status() == "failed"
+        assert_no_slack_errors(slack_errors)
+    finally:
+        cleanup(client, board)
+
+
+def test_plan_only_run_with_stored_plans(client, slack_errors):
+    """Plan-only run: planned verdicts, plans-stored card, no apply column."""
+    names = ["vpc", "eks", "rds"]
+    board = make_board("live-plan", update_interval=0.0)
+    register(board, names, apply=False)
+    try:
+        board.post_or_update(client, force=True)
+        for name in names[:2]:
+            board.mark(name, TerraformAction.INIT, "done")
+            board.mark(name, TerraformAction.PLAN, "changes")
+            board.record_result(
+                name, TerraformAction.PLAN, TerraformResult(2, PLAN_CHANGES, b"")
+            )
+        board.mark(names[2], TerraformAction.INIT, "done")
+        board.record_result(
+            names[2], TerraformAction.PLAN, TerraformResult(0, PLAN_CLEAN, b"")
+        )
+        board.mark(names[2], TerraformAction.PLAN, "done")
+        board.post_or_update(client, force=True)
+
+        assert board.overall_status() == "done"
+        assert_no_slack_errors(slack_errors)
+    finally:
+        cleanup(client, board)

--- a/tests/handlers/test_slack_live.py
+++ b/tests/handlers/test_slack_live.py
@@ -173,10 +173,7 @@ def test_failed_lifecycle_with_overflow_failures(client, slack_errors):
         board.post_or_update(client, force=True)  # in-progress with error cards
 
         # teardown behavior: unfinished becomes skipped, final failed state
-        for rec in board._records.values():
-            for action in board._expected_actions:
-                if rec.statuses.get(action, "pending") in ("pending", "running"):
-                    rec.statuses[action] = "skipped"
+        board.finalize()
         board.post_or_update(client, force=True)
 
         assert board.overall_status() == "failed"

--- a/tests/util/test_util_hooks.py
+++ b/tests/util/test_util_hooks.py
@@ -533,3 +533,529 @@ class TestHelperFunctions:
         extra_vars = {"extra_key": "extra_value"}
         hooks._populate_environment_with_extra_vars(local_env, extra_vars, False)
         assert "TF_EXTRA_EXTRA_KEY" in local_env
+
+
+# Tests for nested remote_vars structures
+class TestResolveTerraformValue:
+    """Tests for _resolve_terraform_value() function."""
+
+    def test_resolve_simple_string_with_specific_output(self):
+        """Test resolving a simple terraform_remote_state reference to specific output."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = "data.terraform_remote_state.network1.outputs.vpc_id"
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == "vpc-123"
+        mock_backend.get_state.assert_called_once_with("network1")
+
+    def test_resolve_string_with_entire_outputs(self):
+        """Test resolving terraform_remote_state reference to entire outputs dict."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+                "subnet_ids": {"value": ["subnet-1", "subnet-2"], "type": "list"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = "data.terraform_remote_state.network1.outputs"
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {
+            "vpc_id": "vpc-123",
+            "subnet_ids": ["subnet-1", "subnet-2"],
+        }
+        mock_backend.get_state.assert_called_once_with("network1")
+
+    def test_resolve_plain_string(self):
+        """Test that plain strings (non-terraform refs) pass through unchanged."""
+        mock_backend = mock.Mock()
+        state_cache = {}
+
+        result = hooks._resolve_terraform_value(
+            "plain_string", mock_backend, state_cache
+        )
+        assert result == "plain_string"
+        mock_backend.get_state.assert_not_called()
+
+    def test_resolve_dict_with_terraform_refs(self):
+        """Test resolving dict with terraform_remote_state references as values."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        state_cache = {}
+        value = {
+            "platform": "data.terraform_remote_state.network1.outputs.vpc_id",
+            "payments": "data.terraform_remote_state.network2.outputs.vpc_id",
+        }
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {
+            "platform": "vpc-123",
+            "payments": "vpc-456",
+        }
+        assert mock_backend.get_state.call_count == 2
+
+    def test_resolve_dict_with_entire_outputs(self):
+        """Test resolving dict where values are entire outputs dicts."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                    "cidr": {"value": "10.0.0.0/16", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                    "cidr": {"value": "10.1.0.0/16", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        state_cache = {}
+        value = {
+            "platform": "data.terraform_remote_state.network1.outputs",
+            "payments": "data.terraform_remote_state.network2.outputs",
+        }
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {
+            "platform": {"vpc_id": "vpc-123", "cidr": "10.0.0.0/16"},
+            "payments": {"vpc_id": "vpc-456", "cidr": "10.1.0.0/16"},
+        }
+
+    def test_resolve_list_with_terraform_refs(self):
+        """Test resolving list with terraform_remote_state references."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        state_cache = {}
+        value = [
+            "data.terraform_remote_state.network1.outputs.vpc_id",
+            "data.terraform_remote_state.network2.outputs.vpc_id",
+        ]
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == ["vpc-123", "vpc-456"]
+        assert mock_backend.get_state.call_count == 2
+
+    def test_resolve_nested_dict(self):
+        """Test resolving deeply nested dict structures."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = {
+            "production": {
+                "primary": "data.terraform_remote_state.network1.outputs.vpc_id",
+            }
+        }
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {"production": {"primary": "vpc-123"}}
+
+    def test_resolve_with_caching(self):
+        """Test that state caching prevents duplicate backend calls."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+                "subnet_id": {"value": "subnet-456", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = {
+            "vpc": "data.terraform_remote_state.network1.outputs.vpc_id",
+            "subnet": "data.terraform_remote_state.network1.outputs.subnet_id",
+        }
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {"vpc": "vpc-123", "subnet": "subnet-456"}
+        # Should only call backend once due to caching
+        mock_backend.get_state.assert_called_once_with("network1")
+
+    def test_resolve_literal_values(self):
+        """Test that literal values (int, bool, etc.) pass through unchanged."""
+        mock_backend = mock.Mock()
+        state_cache = {}
+
+        assert hooks._resolve_terraform_value(42, mock_backend, state_cache) == 42
+        assert hooks._resolve_terraform_value(True, mock_backend, state_cache) is True
+        assert hooks._resolve_terraform_value(None, mock_backend, state_cache) is None
+
+    def test_resolve_output_not_found(self):
+        """Test error when requested output doesn't exist."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = "data.terraform_remote_state.network1.outputs.nonexistent"
+
+        with pytest.raises(hooks.HookError) as exc_info:
+            hooks._resolve_terraform_value(value, mock_backend, state_cache)
+        assert "Output 'nonexistent' not found" in str(exc_info.value)
+
+
+class TestPopulateEnvironmentWithNestedRemoteVars:
+    """Tests for _populate_environment_with_terraform_remote_vars with nested structures."""
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    @mock.patch("tfworker.util.hooks.os.path.isfile", return_value=True)
+    @mock.patch("tfworker.util.hooks.hcl2.loads")
+    def test_populate_with_dict_of_entire_outputs(
+        self, mock_hcl2_loads, mock_isfile, mock_open
+    ):
+        """Test populating environment with dict of entire outputs."""
+        mock_open.return_value.read.return_value = """locals {
+  vpcs = {
+    "platform" = data.terraform_remote_state.network1.outputs
+    "payments" = data.terraform_remote_state.network2.outputs
+  }
+}
+"""
+        mock_hcl2_loads.return_value = {
+            "locals": [
+                {
+                    "vpcs": {
+                        "platform": "data.terraform_remote_state.network1.outputs",
+                        "payments": "data.terraform_remote_state.network2.outputs",
+                    }
+                }
+            ]
+        }
+
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        local_env = {}
+        hooks._populate_environment_with_terraform_remote_vars(
+            local_env, "working_dir", "terraform_path", False, mock_backend
+        )
+
+        assert "TF_REMOTE_VPCS" in local_env
+        # Should be JSON-encoded dict with nested dicts
+        import json
+
+        vpcs_value = json.loads(local_env["TF_REMOTE_VPCS"].strip("'"))
+        assert vpcs_value == {
+            "platform": {"vpc_id": "vpc-123"},
+            "payments": {"vpc_id": "vpc-456"},
+        }
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    @mock.patch("tfworker.util.hooks.os.path.isfile", return_value=True)
+    @mock.patch("tfworker.util.hooks.hcl2.loads")
+    def test_populate_with_list(self, mock_hcl2_loads, mock_isfile, mock_open):
+        """Test populating environment with list of references."""
+        mock_open.return_value.read.return_value = """locals {
+  vpc_ids = [
+    data.terraform_remote_state.network1.outputs.vpc_id,
+    data.terraform_remote_state.network2.outputs.vpc_id,
+  ]
+}
+"""
+        mock_hcl2_loads.return_value = {
+            "locals": [
+                {
+                    "vpc_ids": [
+                        "data.terraform_remote_state.network1.outputs.vpc_id",
+                        "data.terraform_remote_state.network2.outputs.vpc_id",
+                    ]
+                }
+            ]
+        }
+
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        local_env = {}
+        hooks._populate_environment_with_terraform_remote_vars(
+            local_env, "working_dir", "terraform_path", False, mock_backend
+        )
+
+        assert "TF_REMOTE_VPC_IDS" in local_env
+        # Should be JSON-encoded list
+        import json
+
+        vpc_ids_value = json.loads(local_env["TF_REMOTE_VPC_IDS"].strip("'"))
+        assert vpc_ids_value == ["vpc-123", "vpc-456"]
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    @mock.patch("tfworker.util.hooks.os.path.isfile", return_value=True)
+    @mock.patch("tfworker.util.hooks.hcl2.loads")
+    def test_fallback_to_regex_on_hcl2_parse_failure(
+        self, mock_hcl2_loads, mock_isfile, mock_open
+    ):
+        """Test that regex fallback works when HCL2 parsing fails."""
+        mock_locals_content = """locals {
+  local_key = data.terraform_remote_state.example.outputs.key
+}
+"""
+        mock_open.return_value.read.return_value = mock_locals_content
+        # Make HCL2 parsing fail
+        mock_hcl2_loads.side_effect = Exception("HCL2 parse error")
+
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "key": {"value": "test_value", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        local_env = {}
+        # Should fall back to regex parsing
+        with mock.patch(
+            "tfworker.util.hooks.get_state_item",
+            return_value='{"value":"test_value","type":"string"}',
+        ):
+            hooks._populate_environment_with_terraform_remote_vars(
+                local_env, "working_dir", "terraform_path", False, mock_backend
+            )
+
+        assert "TF_REMOTE_LOCAL_KEY" in local_env
+        assert local_env["TF_REMOTE_LOCAL_KEY"] == "test_value"
+
+
+class TestCheckEnvVarSize:
+    """Tests for _check_env_var_size() function."""
+
+    def test_small_variable_no_warning(self, monkeypatch):
+        """Test that small variables don't trigger warnings."""
+        mock_warn = mock.Mock()
+        mock_info = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setattr("tfworker.util.hooks.log.info", mock_info)
+
+        hooks._check_env_var_size("TEST_VAR", "small value", b64_encode=False)
+
+        # Should not log anything for small values
+        mock_warn.assert_not_called()
+        mock_info.assert_not_called()
+
+    def test_variable_approaching_limit_info(self, monkeypatch):
+        """Test that variables approaching limit (>80%) trigger info log."""
+        mock_info = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.info", mock_info)
+        monkeypatch.setenv("SHELL", "/bin/sh")
+
+        # sh limit is 65536, so 85% is ~55705 bytes
+        large_value = "x" * 55705
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_info.assert_called_once()
+        call_arg = mock_info.call_args[0][0]
+        assert "TEST_VAR" in call_arg
+        assert "approaching the sh limit" in call_arg
+        assert "84% of limit" in call_arg or "85% of limit" in call_arg
+
+    def test_variable_exceeding_limit_warning(self, monkeypatch):
+        """Test that variables exceeding limit trigger warning."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setenv("SHELL", "/bin/sh")
+
+        # sh limit is 65536, create value larger than that
+        large_value = "x" * 70000
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        assert "TEST_VAR" in call_arg
+        assert "exceeds the typical sh limit" in call_arg
+        assert "70,000 bytes" in call_arg
+
+    def test_base64_encoded_note_in_warning(self, monkeypatch):
+        """Test that base64 encoding is noted in warning message."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setenv("SHELL", "/bin/sh")
+
+        large_value = "x" * 70000
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=True)
+
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        assert "(base64 encoded)" in call_arg
+
+    def test_bash_shell_limit(self, monkeypatch):
+        """Test that bash shell uses higher limit (128 KB)."""
+        mock_info = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.info", mock_info)
+        monkeypatch.setenv("SHELL", "/bin/bash")
+
+        # bash limit is 131072, so 85% is ~111411 bytes
+        large_value = "x" * 111411
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_info.assert_called_once()
+        call_arg = mock_info.call_args[0][0]
+        assert "approaching the bash limit of 131,072 bytes" in call_arg
+
+    def test_zsh_shell_limit(self, monkeypatch):
+        """Test that zsh shell uses highest limit (1 MB)."""
+        mock_info = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.info", mock_info)
+        monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+
+        # zsh limit is 1048576, so 85% is ~891289 bytes
+        large_value = "x" * 891289
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_info.assert_called_once()
+        call_arg = mock_info.call_args[0][0]
+        assert "approaching the zsh limit of 1,048,576 bytes" in call_arg
+
+    def test_unknown_shell_uses_conservative_limit(self, monkeypatch):
+        """Test that unknown/missing shell uses conservative sh limit."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setenv("SHELL", "/usr/bin/unknown")
+
+        # Should default to sh limit (65536)
+        large_value = "x" * 70000
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        assert "exceeds the typical unknown limit" in call_arg
+
+    def test_no_shell_env_uses_conservative_limit(self, monkeypatch):
+        """Test that missing SHELL env var uses conservative sh limit."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.delenv("SHELL", raising=False)
+
+        # Should default to sh limit (65536)
+        large_value = "x" * 70000
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        # When SHELL is not set, current_shell defaults to "sh"
+        assert "exceeds the typical sh limit" in call_arg
+
+
+class TestSetHookEnvVarWithSizeCheck:
+    """Test that _set_hook_env_var integrates size checking."""
+
+    def test_set_hook_env_var_with_large_dict_warns(self, monkeypatch):
+        """Test that setting large nested dict triggers size warning."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setenv("SHELL", "/bin/sh")
+
+        local_env = {}
+        # Create a large dict that exceeds sh limit (65536 bytes)
+        large_dict = {f"key_{i}": f"value_{i}" * 100 for i in range(1000)}
+
+        hooks._set_hook_env_var(
+            local_env, hooks.TFHookVarType.REMOTE, "LARGE_VAR", large_dict, False
+        )
+
+        assert "TF_REMOTE_LARGE_VAR" in local_env
+        # Should have logged a warning
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        assert "exceeds the typical" in call_arg

--- a/tests/util/test_util_remote_vars.py
+++ b/tests/util/test_util_remote_vars.py
@@ -1,0 +1,479 @@
+"""Unit tests for tfworker.util.remote_vars module."""
+
+import pytest
+
+from tfworker.util.remote_vars import (
+    extract_remote_states,
+    generate_tf_reference,
+    parse_remote_var_reference,
+    parse_tf_reference,
+    validate_remote_vars,
+)
+
+
+class TestParseRemoteVarReference:
+    """Tests for parse_remote_var_reference() function."""
+
+    @pytest.mark.parametrize(
+        "input_ref,expected_state,expected_key",
+        [
+            ("network1.outputs", "network1", None),
+            ("network1.outputs.vpc_id", "network1", "vpc_id"),
+            ("env_info.outputs.environment", "env_info", "environment"),
+            ("network123.outputs.vpc_id", "network123", "vpc_id"),
+            (
+                "remote_state.outputs.data.nested_value",
+                "remote_state",
+                "data.nested_value",
+            ),
+            (
+                'remote_state.outputs.items["test_key"]',
+                "remote_state",
+                'items["test_key"]',
+            ),
+            (
+                'remote_state.outputs.data["test_item"].id',
+                "remote_state",
+                'data["test_item"].id',
+            ),
+            (
+                "state.outputs.level1.level2.level3.level4",
+                "state",
+                "level1.level2.level3.level4",
+            ),
+        ],
+        ids=[
+            "entire_outputs",
+            "specific_key",
+            "with_underscores",
+            "with_numbers",
+            "nested_dot",
+            "nested_bracket",
+            "nested_mixed",
+            "deeply_nested",
+        ],
+    )
+    def test_valid_references(self, input_ref, expected_state, expected_key):
+        """Test parsing valid remote var references."""
+        state, key = parse_remote_var_reference(input_ref)
+        assert state == expected_state
+        assert key == expected_key
+
+    @pytest.mark.parametrize(
+        "invalid_ref,expected_error",
+        [
+            ("network1.vpc_id", "Invalid remote var reference"),
+            ("", "Invalid remote var reference"),
+            ("network-1.outputs.vpc_id", "State name must contain only"),
+            ("network1.outputs.vpc-id", "Use bracket notation"),
+            (".outputs.vpc_id", "State name must contain only"),
+        ],
+        ids=[
+            "missing_outputs",
+            "empty_string",
+            "special_chars_state",
+            "special_chars_key",
+            "missing_state",
+        ],
+    )
+    def test_invalid_references(self, invalid_ref, expected_error):
+        """Test that invalid references raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_remote_var_reference(invalid_ref)
+        assert expected_error in str(exc_info.value)
+
+
+class TestGenerateTfReference:
+    """Tests for generate_tf_reference() function."""
+
+    @pytest.mark.parametrize(
+        "input_ref,expected_output",
+        [
+            ("network1.outputs", "data.terraform_remote_state.network1.outputs"),
+            (
+                "network1.outputs.vpc_id",
+                "data.terraform_remote_state.network1.outputs.vpc_id",
+            ),
+            (
+                "env_info.outputs.environment",
+                "data.terraform_remote_state.env_info.outputs.environment",
+            ),
+            (
+                "remote_state.outputs.data.nested_value",
+                "data.terraform_remote_state.remote_state.outputs.data.nested_value",
+            ),
+            (
+                'remote_state.outputs.items["test_key"]',
+                'data.terraform_remote_state.remote_state.outputs.items["test_key"]',
+            ),
+            (
+                'remote_state.outputs.data["test_item"].id',
+                'data.terraform_remote_state.remote_state.outputs.data["test_item"].id',
+            ),
+        ],
+        ids=[
+            "entire_outputs",
+            "specific_key",
+            "with_underscores",
+            "nested_dot",
+            "nested_bracket",
+            "nested_mixed",
+        ],
+    )
+    def test_valid_generation(self, input_ref, expected_output):
+        """Test generating valid Terraform references."""
+        assert generate_tf_reference(input_ref) == expected_output
+
+    def test_invalid_format(self):
+        """Test that invalid format raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            generate_tf_reference("invalid.reference")
+        assert "Invalid remote var reference" in str(exc_info.value)
+
+
+class TestExtractRemoteStates:
+    """Tests for extract_remote_states() function."""
+
+    @pytest.mark.parametrize(
+        "value,expected_states",
+        [
+            ("network1.outputs.vpc_id", {"network1"}),
+            ("network1.outputs", {"network1"}),
+            ({"k1": "net1.outputs", "k2": "net2.outputs.vpc"}, {"net1", "net2"}),
+            (
+                ["net1.outputs", "net2.outputs.id", "net3.outputs.name"],
+                {"net1", "net2", "net3"},
+            ),
+            ({}, set()),
+            ([], set()),
+        ],
+        ids=[
+            "simple_string",
+            "string_entire_outputs",
+            "dict_single_level",
+            "list",
+            "empty_dict",
+            "empty_list",
+        ],
+    )
+    def test_extract_basic_cases(self, value, expected_states):
+        """Test extracting state names from various structures."""
+        assert extract_remote_states(value) == expected_states
+
+    def test_extract_from_nested_dict(self):
+        """Test extracting state names from nested dict structure."""
+        states = extract_remote_states(
+            {
+                "vpcs": {"platform": "net1.outputs", "payments": "net2.outputs.vpc"},
+                "env": "env_info.outputs.environment",
+            }
+        )
+        assert states == {"net1", "net2", "env_info"}
+
+    def test_extract_from_nested_list_in_dict(self):
+        """Test extracting state names from list nested in dict."""
+        states = extract_remote_states(
+            {
+                "vpc_ids": ["net1.outputs.vpc_id", "net2.outputs.vpc_id"],
+                "env": "env_info.outputs.environment",
+            }
+        )
+        assert states == {"net1", "net2", "env_info"}
+
+    def test_extract_from_dict_in_list(self):
+        """Test extracting state names from dict nested in list."""
+        states = extract_remote_states(
+            [{"name": "net1.outputs.name"}, {"name": "net2.outputs.name"}]
+        )
+        assert states == {"net1", "net2"}
+
+    def test_extract_from_deeply_nested_structure(self):
+        """Test extracting state names from deeply nested structure."""
+        states = extract_remote_states(
+            {
+                "networks": {
+                    "production": {
+                        "primary": "net1.outputs",
+                        "secondary": "net2.outputs",
+                    },
+                    "staging": ["net3.outputs.vpc_id", "net4.outputs.vpc_id"],
+                },
+                "databases": [
+                    {"primary": "db1.outputs.endpoint"},
+                    {"replica": "db2.outputs.endpoint"},
+                ],
+            }
+        )
+        assert states == {"net1", "net2", "net3", "net4", "db1", "db2"}
+
+    def test_extract_duplicate_states(self):
+        """Test that duplicate state names are deduplicated."""
+        states = extract_remote_states(
+            {
+                "vpc_id": "net1.outputs.vpc_id",
+                "subnet_ids": "net1.outputs.subnet_ids",
+                "cidr": "net1.outputs.cidr",
+            }
+        )
+        assert states == {"net1"}
+
+
+class TestParseTfReference:
+    """Tests for parse_tf_reference() function."""
+
+    @pytest.mark.parametrize(
+        "tf_ref,expected_state,expected_key",
+        [
+            ("data.terraform_remote_state.network1.outputs", "network1", None),
+            (
+                "data.terraform_remote_state.network1.outputs.vpc_id",
+                "network1",
+                "vpc_id",
+            ),
+            (
+                "data.terraform_remote_state.env_info.outputs.environment",
+                "env_info",
+                "environment",
+            ),
+            (
+                "data.terraform_remote_state.remote_state.outputs.data.nested_value",
+                "remote_state",
+                "data.nested_value",
+            ),
+            (
+                'data.terraform_remote_state.remote_state.outputs.items["test_key"]',
+                "remote_state",
+                'items["test_key"]',
+            ),
+            (
+                'data.terraform_remote_state.remote_state.outputs.data["test_item"].id',
+                "remote_state",
+                'data["test_item"].id',
+            ),
+        ],
+        ids=[
+            "entire_outputs",
+            "specific_key",
+            "with_underscores",
+            "nested_dot",
+            "nested_bracket",
+            "nested_mixed",
+        ],
+    )
+    def test_valid_parsing(self, tf_ref, expected_state, expected_key):
+        """Test parsing valid Terraform references."""
+        state, key = parse_tf_reference(tf_ref)
+        assert state == expected_state
+        assert key == expected_key
+
+    @pytest.mark.parametrize(
+        "invalid_ref,expected_error",
+        [
+            (
+                "terraform_remote_state.network1.outputs",
+                "Invalid Terraform remote state reference",
+            ),
+            (
+                "data.remote_state.network1.outputs",
+                "Invalid Terraform remote state reference",
+            ),
+            (
+                "data.terraform_remote_state.network1.vpc_id",
+                "Invalid Terraform remote state reference",
+            ),
+            ("", "Invalid Terraform remote state reference"),
+        ],
+        ids=[
+            "missing_data_prefix",
+            "wrong_middle",
+            "missing_outputs",
+            "empty_string",
+        ],
+    )
+    def test_invalid_parsing(self, invalid_ref, expected_error):
+        """Test that invalid references raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_tf_reference(invalid_ref)
+        assert expected_error in str(exc_info.value)
+
+
+class TestValidateRemoteVars:
+    """Tests for validate_remote_vars() function."""
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {"env": "env_info.outputs.environment"},
+            {"vpcs": {"platform": "net1.outputs", "payments": "net2.outputs.vpc"}},
+            {"vpc_ids": ["net1.outputs.vpc_id", "net2.outputs.vpc_id"]},
+            {
+                "networks": {
+                    "production": {
+                        "primary": "net1.outputs",
+                        "secondary": "net2.outputs",
+                    }
+                },
+                "databases": ["db1.outputs.endpoint"],
+            },
+            {},
+        ],
+        ids=[
+            "simple_string",
+            "dict_structure",
+            "list_structure",
+            "nested_structure",
+            "empty_dict",
+        ],
+    )
+    def test_valid_configs(self, config):
+        """Test validating valid remote_vars configurations."""
+        validate_remote_vars(config)  # Should not raise
+
+    @pytest.mark.parametrize(
+        "config,expected_error",
+        [
+            (
+                {"bad": "invalid.reference"},
+                "Invalid remote_vars configuration for key 'bad'",
+            ),
+            (
+                {"vpcs": {"platform": "invalid.reference"}},
+                "Invalid remote_vars configuration for key 'vpcs'",
+            ),
+            ({"items": [123, 456]}, "Unsupported remote_vars value type"),
+            (
+                {"valid": "net1.outputs.vpc", "invalid": "bad.reference"},
+                "Invalid remote_vars configuration for key 'invalid'",
+            ),
+        ],
+        ids=[
+            "invalid_string",
+            "invalid_nested_string",
+            "invalid_type_in_list",
+            "multiple_keys_one_invalid",
+        ],
+    )
+    def test_invalid_configs(self, config, expected_error):
+        """Test that invalid configurations raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_remote_vars(config)
+        assert expected_error in str(exc_info.value)
+
+
+class TestIntegrationScenarios:
+    """Integration tests for common usage scenarios."""
+
+    def test_standard_string_references(self):
+        """Test that standard string references work correctly."""
+        config = {
+            "global_ipv4_blacklist": "env_info.outputs.global_ipv4_blacklist",
+            "vpcs": "env_info.outputs.vpcs",
+            "waf_ip_lists": "env_info.outputs.waf_ip_lists",
+            "environment": "env_info.outputs.environment",
+        }
+
+        # Validate
+        validate_remote_vars(config)
+
+        # Extract states
+        all_states = set()
+        for value in config.values():
+            all_states.update(extract_remote_states(value))
+        assert all_states == {"env_info"}
+
+        # Generate Terraform references
+        for key, value in config.items():
+            tf_ref = generate_tf_reference(value)
+            assert tf_ref.startswith("data.terraform_remote_state.env_info.outputs.")
+
+    def test_new_dict_structure_entire_outputs(self):
+        """Test new dict structure with entire outputs."""
+        config = {
+            "vpcs": {
+                "platform-tools": "network1.outputs",
+                "payments-network": "network2.outputs",
+            }
+        }
+
+        # Validate
+        validate_remote_vars(config)
+
+        # Extract states
+        states = extract_remote_states(config["vpcs"])
+        assert states == {"network1", "network2"}
+
+        # Generate Terraform references
+        for key, value in config["vpcs"].items():
+            tf_ref = generate_tf_reference(value)
+            state, output_key = parse_tf_reference(tf_ref)
+            assert output_key is None  # Entire outputs requested
+
+    def test_new_dict_structure_specific_keys(self):
+        """Test new dict structure with specific output keys."""
+        config = {
+            "vpc_configs": {
+                "platform": "network1.outputs.vpc_config",
+                "payments": "network2.outputs.vpc_config",
+            }
+        }
+
+        # Validate
+        validate_remote_vars(config)
+
+        # Extract states
+        states = extract_remote_states(config["vpc_configs"])
+        assert states == {"network1", "network2"}
+
+        # Generate Terraform references
+        for key, value in config["vpc_configs"].items():
+            tf_ref = generate_tf_reference(value)
+            state, output_key = parse_tf_reference(tf_ref)
+            assert output_key == "vpc_config"
+
+    def test_new_list_structure(self):
+        """Test new list structure."""
+        config = {
+            "all_vpc_ids": [
+                "network1.outputs.vpc_id",
+                "network2.outputs.vpc_id",
+                "network3.outputs.vpc_id",
+            ]
+        }
+
+        # Validate
+        validate_remote_vars(config)
+
+        # Extract states
+        states = extract_remote_states(config["all_vpc_ids"])
+        assert states == {"network1", "network2", "network3"}
+
+        # Generate Terraform references
+        for value in config["all_vpc_ids"]:
+            tf_ref = generate_tf_reference(value)
+            state, output_key = parse_tf_reference(tf_ref)
+            assert output_key == "vpc_id"
+
+    def test_mixed_simple_and_complex(self):
+        """Test config with mix of simple and complex structures."""
+        config = {
+            # Simple (existing)
+            "environment": "env_info.outputs.environment",
+            # Dict with entire outputs
+            "vpcs": {"platform": "network1.outputs", "payments": "network2.outputs"},
+            # List
+            "vpc_ids": ["network1.outputs.vpc_id", "network2.outputs.vpc_id"],
+            # Dict with specific keys
+            "endpoints": {
+                "db_primary": "db1.outputs.endpoint",
+                "db_replica": "db2.outputs.endpoint",
+            },
+        }
+
+        # Validate entire config
+        validate_remote_vars(config)
+
+        # Extract all states
+        all_states = set()
+        for value in config.values():
+            all_states.update(extract_remote_states(value))
+        assert all_states == {"env_info", "network1", "network2", "db1", "db2"}

--- a/tfworker/authenticators/aws.py
+++ b/tfworker/authenticators/aws.py
@@ -20,8 +20,10 @@ class AWSAuthenticatorConfig(BaseAuthenticatorConfig):
     Attributes:
         aws_region (str): the AWS region to use. This is required.
         aws_access_key_id (str): an aws access key id. Either this or a profile is required.
+            When provided with a secret access key, it takes precedence over aws_profile.
         aws_external_id (str): a unique ID that can be used for cross account assumptions. Defaults to None.
         aws_profile (str): an aws profile. Either this or an access key id is required.
+            Ignored when an access key id and secret access key are also provided.
         aws_role_arn (str): if provided, the role to assume using other creds. Defaults to None.
         aws_secret_access_key (str): an aws secret access key. Either this or a profile is required.
         aws_session_token (str): an aws session token. Defaults to None.
@@ -284,6 +286,15 @@ def _get_init_session_args(auth_config: AWSAuthenticatorConfig) -> Dict[str, str
     """
     Returns a dictionary of arguments to pass to the initial boto3 session
 
+    Explicit credentials take precedence over a profile: when an access key and
+    secret are supplied, the profile is not passed to boto3 at all. The two are
+    alternative sources for the same session, and passing both requires the
+    named profile to also exist wherever the worker runs -- boto3 raises
+    ProfileNotFound while constructing the session, before the explicit
+    credentials it would have preferred are ever consulted. Environments that
+    supply credentials directly (CI, a container using its task/pod identity to
+    assume a role) can therefore ignore the aws_profile in the config file.
+
     Args:
         auth_config (AWSAuthenticatorConfig): the configuration for the authenticator
 
@@ -292,8 +303,18 @@ def _get_init_session_args(auth_config: AWSAuthenticatorConfig) -> Dict[str, str
     """
     session_args = dict()
 
+    has_explicit_creds = (
+        auth_config.aws_access_key_id is not None
+        and auth_config.aws_secret_access_key is not None
+    )
+
     if auth_config.aws_profile is not None:
-        session_args["profile_name"] = auth_config.aws_profile
+        if has_explicit_creds:
+            log.debug(
+                f"ignoring profile {auth_config.aws_profile}, explicit credentials were provided"
+            )
+        else:
+            session_args["profile_name"] = auth_config.aws_profile
 
     if auth_config.aws_access_key_id is not None:
         session_args["aws_access_key_id"] = auth_config.aws_access_key_id

--- a/tfworker/backends/s3.py
+++ b/tfworker/backends/s3.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Generator
 import boto3.dynamodb
 import botocore
 import botocore.errorfactory
+import botocore.exceptions
 import botocore.paginate
 import click
 
@@ -77,9 +78,27 @@ class S3Backend(BaseBackend):
         self._s3_client: botocore.client.S3 = (
             self._authenticator.backend_session.client("s3")
         )
-        self._ensure_locking_table()
-        self._ensure_backend_bucket()
-        self._bucket_files: list = self._list_bucket_definitions()
+
+        try:
+            self._ensure_locking_table()
+            self._ensure_backend_bucket()
+            self._bucket_files: list = self._list_bucket_definitions()
+        except (
+            botocore.exceptions.TokenRetrievalError,
+            botocore.exceptions.NoCredentialsError,
+            botocore.exceptions.PartialCredentialsError,
+        ) as e:
+            raise BackendError(f"AWS authentication failed: {e}") from e
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in (
+                "ExpiredToken",
+                "InvalidClientTokenId",
+                "SignatureDoesNotMatch",
+                "AccessDenied",
+            ):
+                raise BackendError(f"AWS authentication failed: {e}") from e
+            raise
 
     @property
     def remotes(self) -> list:

--- a/tfworker/definitions/model.py
+++ b/tfworker/definitions/model.py
@@ -55,9 +55,11 @@ class Definition(BaseModel):
     terraform_vars: Optional[Dict[str, Any]] = Field(
         {}, description="Variables to pass to terraform via a generated .tfvars file."
     )
-    remote_vars: Optional[Dict[str, str]] = Field(
+    remote_vars: Optional[Dict[str, str | Dict | list]] = Field(
         {},
-        description="Variables which are used to generate local references to remote state vars.",
+        description="Variables which are used to generate local references to remote state vars. "
+        "Supports strings (e.g., 'state.outputs.key'), dicts for mapping keys to remote refs, "
+        "and lists of remote refs.",
     )
     squelch_plan_output: bool = False
     squelch_apply_output: bool = False

--- a/tfworker/definitions/prepare.py
+++ b/tfworker/definitions/prepare.py
@@ -95,8 +95,55 @@ class DefinitionPrepare:
             for k, v in definition.get_remote_vars(
                 global_vars=self._app_state.loaded_config.global_vars.remote_vars
             ).items():
-                tflocals.write(f"  {k} = data.terraform_remote_state.{v}\n")
+                # Generate Terraform HCL for the value (handles str/dict/list)
+                tf_value = self._generate_tf_value(v, indent=1)
+                tflocals.write(f"  {k} = {tf_value}\n")
             tflocals.write("}\n\n")
+
+    def _generate_tf_value(self, value: Union[str, Dict, list], indent: int = 0) -> str:
+        """
+        Recursively generate Terraform HCL for a remote_vars value.
+
+        Args:
+            value: The remote_vars value (string ref, dict, or list)
+            indent: Current indentation level
+
+        Returns:
+            Terraform HCL string
+
+        Raises:
+            ValueError: If the value type is unsupported
+        """
+        from tfworker.util.remote_vars import generate_tf_reference
+
+        if isinstance(value, str):
+            # Simple string reference: "state.outputs.key"
+            return generate_tf_reference(value)
+
+        elif isinstance(value, dict):
+            # Dict: {"k1": "state1.outputs", "k2": "state2.outputs.key"}
+            if not value:
+                return "{}"
+            lines = ["{"]
+            for key, val in value.items():
+                nested_value = self._generate_tf_value(val, indent + 1)
+                lines.append(f'{"  " * (indent + 1)}"{key}" = {nested_value}')
+            lines.append(f'{"  " * indent}}}')
+            return "\n".join(lines)
+
+        elif isinstance(value, list):
+            # List: ["state1.outputs", "state2.outputs.key"]
+            if not value:
+                return "[]"
+            lines = ["["]
+            for item in value:
+                nested_value = self._generate_tf_value(item, indent + 1)
+                lines.append(f'{"  " * (indent + 1)}{nested_value},')
+            lines.append(f'{"  " * indent}]')
+            return "\n".join(lines)
+
+        else:
+            raise ValueError(f"Unsupported remote_vars value type: {type(value)}")
 
     def create_worker_tf(self, name: str) -> None:
         """Create remote data sources, and required providers"""
@@ -197,20 +244,21 @@ class DefinitionPrepare:
 
     def _get_remotes(self, name: str) -> list:
         """Get the remote data sources"""
+        from tfworker.util.remote_vars import extract_remote_states
+
         definition = self._app_state.definitions[name]
         log.trace(f"getting remotes for definition {name}")
         if self._app_state.terraform_options.backend_use_all_remotes:
             log.trace(f"using all remotes for definition {name}")
             remotes = self._app_state.backend.remotes
         else:
-            remotes = list(
-                map(
-                    lambda x: x.split(".")[0],
-                    definition.get_remote_vars(
-                        global_vars=self._app_state.loaded_config.global_vars.remote_vars
-                    ).values(),
-                )
-            )
+            # Extract state names from all remote_vars values (recursive)
+            remote_states = set()
+            for value in definition.get_remote_vars(
+                global_vars=self._app_state.loaded_config.global_vars.remote_vars
+            ).values():
+                remote_states.update(extract_remote_states(value))
+            remotes = list(remote_states)
             log.trace(f"using remotes {remotes} for definition {name}")
         return remotes
 

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -33,6 +33,9 @@ Notes on Slack API behavior this module encodes (all confirmed live):
 - ``data_table`` cells reject ``raw_number``; numeric columns use ``raw_text``.
 - ``plan`` blocks keep a stable ``block_id`` across updates: a fresh id makes
   Slack treat the block as new and reset its expanded/collapsed state.
+- The ``<!date>`` command renders in section/context blocks (including
+  container children) but NOT in the container title or subtitle, where the
+  raw syntax is displayed literally.
 - ``blocks.validate`` accepts payloads the message APIs reject; only real
   ``chat.postMessage``/``chat.update`` calls prove a payload.
 - The bot token only has ``chat:write``/``chat:write.public`` so every posted
@@ -522,10 +525,10 @@ class SlackStatusBoard:
         elif self._commit:
             parts.append(f"commit `{self._commit}`")
         if self.overall_status() == "in_progress":
-            # plain clocks: the container subtitle does not process Slack's
-            # <!date> command — it renders the syntax literally
+            # plain clock: the container subtitle does not process Slack's
+            # <!date> command — it renders the syntax literally. The live
+            # "updated N ago" lives in the links context, which does.
             parts.append(f"started {self._clock(self._started_wall)}")
-            parts.append(f"updated {self._clock(datetime.now(timezone.utc))}")
         else:
             parts.append(f"finished in {self._elapsed_text()}")
         return " · ".join(parts)
@@ -632,10 +635,22 @@ class SlackStatusBoard:
 
     def _links_context(self) -> dict:
         text = ":thread: per-definition table in thread" + self._links_suffix()
+        elements = [{"type": "mrkdwn", "text": text}]
+        if self.overall_status() == "in_progress":
+            now = datetime.now(timezone.utc)
+            elements.append(
+                {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"updated <!date^{int(now.timestamp())}^{{ago}}"
+                        f"|{self._clock(now)}>"
+                    ),
+                }
+            )
         return {
             "type": "context",
             "block_id": "run_links",
-            "elements": [{"type": "mrkdwn", "text": text}],
+            "elements": elements,
         }
 
     def _failures_table(self, failed: list[DefinitionRecord]) -> list[dict]:
@@ -1076,13 +1091,22 @@ class SlackStatusBoard:
     def _normalize_for_compare(blocks: list[dict]) -> list[dict]:
         """Blocks minus volatile fields, so no-op updates can be skipped.
 
-        The container subtitle carries an "updated HH:MM" clock, which alone
-        should not force a send.
+        The subtitle's "started" clock and the links context's live
+        "updated N ago" timestamp change with every render; neither alone
+        should force a send.
         """
         normalized = copy.deepcopy(blocks)
         for block in normalized:
-            if block.get("type") == "container" and "subtitle" in block:
-                block["subtitle"] = {}
+            if block.get("type") != "container":
+                continue
+            block["subtitle"] = {}
+            for child in block.get("child_blocks", []):
+                if child.get("block_id") == "run_links":
+                    child["elements"] = [
+                        e
+                        for e in child["elements"]
+                        if not e.get("text", "").startswith("updated ")
+                    ]
         return normalized
 
     def _call_api(self, method, force: bool, **kwargs):

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -778,27 +778,28 @@ class SlackStatusBoard:
         rollup = self._rollup_complete_task(buckets)
         if rollup:
             tasks.append(rollup)
+        # shown while running too: clean finishes are completed work, and on
+        # an all-clean run this is otherwise the feed's only sign of progress
+        if buckets["no_changes"]:
+            tasks.append(
+                {
+                    "task_id": "rollup_no_changes",
+                    "title": (
+                        f"{len(buckets['no_changes'])} definitions with no changes"
+                    ),
+                    "status": "complete",
+                    "details": _rich_text(
+                        [
+                            {
+                                "type": "text",
+                                "text": self._name_list(buckets["no_changes"]),
+                            }
+                        ]
+                    ),
+                }
+            )
 
         if overall == "done":
-            if buckets["no_changes"]:
-                tasks.append(
-                    {
-                        "task_id": "rollup_no_changes",
-                        "title": (
-                            f"{len(buckets['no_changes'])} definitions with "
-                            "no changes"
-                        ),
-                        "status": "complete",
-                        "details": _rich_text(
-                            [
-                                {
-                                    "type": "text",
-                                    "text": self._name_list(buckets["no_changes"]),
-                                }
-                            ]
-                        ),
-                    }
-                )
             if buckets["skipped"]:
                 tasks.append(
                     {

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -510,11 +510,6 @@ class SlackStatusBoard:
     def _links_suffix(self) -> str:
         return "".join(f" · <{lk.url}|{lk.text}>" for lk in self._config.links)
 
-    def _slack_date(self, dt: datetime, token: str) -> str:
-        """Slack date mrkdwn: rendered in the viewer's local time (or as a
-        relative "N minutes ago" for {ago}), with a UTC clock fallback."""
-        return f"<!date^{int(dt.timestamp())}^{{{token}}}|{self._clock(dt)}>"
-
     def _subtitle(self) -> str:
         parts: list[str] = []
         if self._run_id:
@@ -527,10 +522,10 @@ class SlackStatusBoard:
         elif self._commit:
             parts.append(f"commit `{self._commit}`")
         if self.overall_status() == "in_progress":
-            parts.append(f"started {self._slack_date(self._started_wall, 'time')}")
-            parts.append(
-                f"updated {self._slack_date(datetime.now(timezone.utc), 'ago')}"
-            )
+            # plain clocks: the container subtitle does not process Slack's
+            # <!date> command — it renders the syntax literally
+            parts.append(f"started {self._clock(self._started_wall)}")
+            parts.append(f"updated {self._clock(datetime.now(timezone.utc))}")
         else:
             parts.append(f"finished in {self._elapsed_text()}")
         return " · ".join(parts)

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -1,7 +1,10 @@
 """Slack handler for terraform-worker.
 
-Posts a single live-updating status board message to a Slack channel,
-updating it in-place as definitions progress through terraform actions.
+Posts a compact, live-updating Block Kit report for each run: one channel
+message (a ``container`` header card plus a ``plan`` "Run progress" activity
+feed) and one threaded reply holding the full per-definition ``data_table``.
+The channel message stays a fixed size regardless of how many definitions the
+run contains; the thread table holds the full detail.
 
 Example configuration::
 
@@ -10,16 +13,42 @@ Example configuration::
         channel: "#terraform-runs"
         token: "xoxb-..."          # raw value; supports jinja injection
         # token_env: "SLACK_BOT_TOKEN"  # env var name (default)
-        title: "Prod deployment"   # optional; falls back to deployment name
+        title: "apps/qa"           # optional; falls back to deployment name
+        links:                     # optional links shown in the header card
+          - text: "Argo workflow"
+            url: "https://argo.example/workflows/ops/{{ env.WORKFLOW_NAME }}"
+          - text: "logs"
+            url: "https://app.datadoghq.com/logs?query=service%3Aneptune-executor"
+        # per-definition deep link used on failure cards; {definition} is
+        # replaced with the definition name
+        definition_log_url_template: "https://app.datadoghq.com/logs?query=service%3Aneptune-executor%20%40definition%3A{definition}"
+        update_interval: 4.0       # min seconds between Slack updates
+
+Notes on Slack API behavior this module encodes (all confirmed live):
+
+- ``has_header_divider`` and ``is_collapsible`` on a container are mutually
+  exclusive at post/update time.
+- ``data_table`` cells reject ``raw_number``; numeric columns use ``raw_text``.
+- ``plan`` blocks should get a fresh ``block_id`` on every ``chat.update``.
+- ``blocks.validate`` accepts payloads the message APIs reject; only real
+  ``chat.postMessage``/``chat.update`` calls prove a payload.
+- The bot token only has ``chat:write``/``chat:write.public`` so every posted
+  message ``ts`` is tracked locally (the bot cannot read the thread back).
 """
 
+import copy
 import os
+import re
 import subprocess
-from typing import TYPE_CHECKING, Union
+import threading
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Optional, Union
 
 import click
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
 
 import tfworker.util.log as log
 from tfworker.custom_types.terraform import TerraformAction, TerraformStage
@@ -31,12 +60,28 @@ if TYPE_CHECKING:
     from tfworker.commands.terraform import TerraformResult
     from tfworker.definitions.model import Definition
 
+TERMINAL_STATUSES = frozenset({"done", "changes", "failed", "skipped"})
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_PLAN_LINE_RE = re.compile(r"Plan: [^\n]*")
+_PLAN_COUNT_RE = re.compile(r"(\d+) to (?:import|add|change|destroy)")
+_APPLY_LINE_RE = re.compile(r"(?:Apply|Destroy) complete! Resources: [^\n]*")
+_APPLY_COUNT_RE = re.compile(r"(\d+) (?:imported|added|changed|destroyed)")
+
+
+class SlackLink(BaseModel):
+    text: str
+    url: str
+
 
 class SlackConfig(BaseModel):
     channel: str
     token: str | None = Field(default=None, repr=False)
     token_env: str = "SLACK_BOT_TOKEN"
     title: str | None = None
+    links: list[SlackLink] = Field(default_factory=list)
+    definition_log_url_template: str | None = None
+    update_interval: float = Field(default=4.0, ge=0.0)
 
     _resolved_token: str = PrivateAttr(default="")
 
@@ -59,95 +104,206 @@ class SlackConfig(BaseModel):
         return self._resolved_token
 
 
-class SlackStatusBoard:
-    """Internal state machine for the Slack status board message."""
+def _rich_text(elements: list[dict]) -> dict:
+    return {
+        "type": "rich_text",
+        "elements": [{"type": "rich_text_section", "elements": elements}],
+    }
 
-    STATUS_EMOJI: dict[str, str] = {
-        "pending": "⏳",
-        "running": "🔄",
-        "done": "✅",
-        "changes": "🔵",
-        "failed": "❌",
-        "skipped": "—",
+
+def _truncate(text: str, limit: int) -> str:
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+class DefinitionRecord:
+    """Per-definition state accumulated over a run."""
+
+    __slots__ = (
+        "name",
+        "statuses",
+        "started_at",
+        "finished_at",
+        "plan_line",
+        "planned_changes",
+        "applied_changes",
+        "error_action",
+        "error_snippet",
+    )
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.statuses: dict[str, str] = {}
+        self.started_at: float | None = None
+        self.finished_at: float | None = None
+        self.plan_line: str | None = None
+        self.planned_changes: int | None = None
+        self.applied_changes: int | None = None
+        self.error_action: str | None = None
+        self.error_snippet: str | None = None
+
+    def duration_secs(self) -> int | None:
+        if self.started_at is None or self.finished_at is None:
+            return None
+        return int(self.finished_at - self.started_at)
+
+
+class SlackStatusBoard:
+    """Builds and maintains the run's Slack messages.
+
+    One channel message (container + plan block) is posted at setup and
+    updated in place; the per-definition table is posted as threaded
+    ``data_table`` replies. Updates are debounced to ``update_interval``
+    seconds (terminal flushes bypass the debounce) and 429s are honored.
+    """
+
+    # data_table emoji per status; skipped renders as plain "—" text
+    RICH_STATUS_EMOJI: dict[str, str] = {
+        "pending": "hourglass",
+        "running": "arrows_counterclockwise",
+        "done": "white_check_mark",
+        "changes": "large_blue_circle",
+        "failed": "x",
     }
     ACTION_ORDER: list[str] = ["init", "plan", "apply", "destroy"]
-    # Slack allows at most 50 blocks per message; keep detail rows well under it.
-    MAX_BLOCKS: int = 50
-    DETAIL_ROWS_PER_MSG: int = 45
+    ACTION_NOUNS: dict[str, tuple[str, str, str]] = {
+        # action -> (noun, present participle, past tense)
+        "plan": ("Plan", "Planning", "planned"),
+        "apply": ("Apply", "Applying", "applied"),
+        "destroy": ("Destroy", "Destroying", "destroyed"),
+        "init": ("Init", "Initializing", "initialized"),
+    }
+    MAX_ERROR_CARDS: int = 5
+    MAX_NAMED_RUNNING: int = 2
+    MAX_FAILURE_TABLE_ROWS: int = 5
+    MAX_DATA_TABLE_ROWS: int = 200
+    DATA_TABLE_PAGE_SIZE: int = 15
+    FAILURE_ERROR_CHARS: int = 80
+    CARD_ERROR_CHARS: int = 200
 
-    def __init__(self, channel: str, title: str | None, run_id: str | None):
-        self._ts: str | None = None
-        self._channel = channel
-        self._statuses: dict[str, dict[str, str]] = {}
-        self._seen_actions: list[str] = []
-        self._deployment: str | None = None
+    def __init__(
+        self,
+        config: SlackConfig,
+        run_id: str | None,
+        backend_plans: bool = False,
+    ) -> None:
+        self._config = config
+        self._channel = config.channel
         self._run_id = run_id
-        self._title = title
-        self._git_context: str | None = None
-        # Parent (summary) message ts is `_ts`; threaded detail messages are
-        # `_detail_ts`. We cache the last blocks sent for each so repeated
-        # post_or_update calls skip no-op Slack updates.
-        self._detail_ts: list[str] = []
-        self._parent_blocks_sent: Union[list, None] = None
-        self._detail_blocks_sent: list[list] = []
+        self._backend_plans = backend_plans
 
+        self._records: dict[str, DefinitionRecord] = {}
+        self._expected_actions: list[str] = []
+        self._primary_action: str = "plan"
+        self._deployment: str | None = None
+        self._branch: str | None = None
+        self._commit: str | None = None
+
+        self._started_monotonic = time.monotonic()
+        self._started_wall = datetime.now(timezone.utc)
+
+        self._lock = threading.RLock()
+        self._seq = 0
+        self._next_update_at = 0.0
+        self._ts: str | None = None
+        self._thread_ts: list[str] = []
+        self._main_sent: Union[list, None] = None
+        self._thread_sent: list[list] = []
+
+    # ------------------------------------------------------------------
+    # state updates
+    # ------------------------------------------------------------------
     def ensure_definition(
         self, definition_name: str, deployment: str, working_dir: str
     ) -> None:
         """Register a definition and capture run context on first call."""
-        if self._deployment is None:
-            self._deployment = deployment
-            self._git_context = self._resolve_git_context(working_dir)
-        if definition_name not in self._statuses:
-            self._statuses[definition_name] = {}
+        with self._lock:
+            if self._deployment is None:
+                self._deployment = deployment
+                self._resolve_git_context(working_dir)
+            if definition_name not in self._records:
+                self._records[definition_name] = DefinitionRecord(definition_name)
+
+    def set_expected_actions(self, actions: list[TerraformAction]) -> None:
+        """Set the action columns for the run and derive the primary action."""
+        with self._lock:
+            vals = [a.value for a in actions]
+            self._expected_actions = [a for a in self.ACTION_ORDER if a in vals]
+            for candidate in ("destroy", "apply", "plan", "init"):
+                if candidate in self._expected_actions:
+                    self._primary_action = candidate
+                    break
 
     def mark(self, definition_name: str, action: TerraformAction, status: str) -> None:
         """Update the status of a definition+action pair."""
-        action_val = action.value
-        if action_val not in self._seen_actions:
-            self._seen_actions = [
-                a for a in self.ACTION_ORDER if a in self._seen_actions + [action_val]
-            ]
-        if definition_name not in self._statuses:
-            self._statuses[definition_name] = {}
-        self._statuses[definition_name][action_val] = status
+        with self._lock:
+            action_val = action.value
+            if action_val not in self._expected_actions:
+                self._expected_actions = [
+                    a
+                    for a in self.ACTION_ORDER
+                    if a in self._expected_actions + [action_val]
+                ]
+            if definition_name not in self._records:
+                self._records[definition_name] = DefinitionRecord(definition_name)
+            rec = self._records[definition_name]
+            rec.statuses[action_val] = status
+            now = time.monotonic()
+            if status == "running" and rec.started_at is None:
+                rec.started_at = now
+            if status in TERMINAL_STATUSES and self._classify(rec) not in (
+                "running",
+                "queued",
+            ):
+                rec.finished_at = now
 
-    def is_terminal(self) -> bool:
-        """Return True when no definition+action remains pending or running."""
-        for action_statuses in self._statuses.values():
-            for action_val in self._seen_actions:
-                if action_statuses.get(action_val, "pending") in ("pending", "running"):
-                    return False
-        return True
+    def record_result(
+        self,
+        definition_name: str,
+        action: TerraformAction,
+        result: Optional["TerraformResult"],
+        failed: bool = False,
+    ) -> None:
+        """Capture plan/apply output details or an error snippet for a definition."""
+        if result is None:
+            return
+        with self._lock:
+            rec = self._records.get(definition_name)
+            if rec is None:
+                return
+            text = _ANSI_RE.sub("", f"{result.stdout_str}\n{result.stderr_str}")
+            if failed:
+                rec.error_action = action.value
+                rec.error_snippet = self._extract_error(text)
+                return
+            if action == TerraformAction.PLAN:
+                match = _PLAN_LINE_RE.search(text)
+                if match:
+                    rec.plan_line = match.group(0).rstrip(".")
+                    rec.planned_changes = sum(
+                        int(n) for n in _PLAN_COUNT_RE.findall(match.group(0))
+                    )
+                elif "No changes." in text:
+                    rec.planned_changes = 0
+            elif action in (TerraformAction.APPLY, TerraformAction.DESTROY):
+                match = _APPLY_LINE_RE.search(text)
+                if match:
+                    rec.applied_changes = sum(
+                        int(n) for n in _APPLY_COUNT_RE.findall(match.group(0))
+                    )
 
-    def overall_status(self) -> str:
-        """Return 'in_progress', 'failed', or 'done'."""
-        if not self.is_terminal():
-            return "in_progress"
-        for action_statuses in self._statuses.values():
-            if "failed" in action_statuses.values():
-                return "failed"
-        return "done"
+    @staticmethod
+    def _extract_error(text: str) -> str:
+        """Pull the most useful error line(s) out of terraform output."""
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        for i, line in enumerate(lines):
+            if "Error:" in line:
+                return " ".join(lines[i : i + 3])
+        return " ".join(lines[-3:]) if lines else "unknown error"
 
-    def failed_count(self) -> int:
-        """Return number of definition+action pairs that failed."""
-        return sum(
-            1
-            for action_statuses in self._statuses.values()
-            for status in action_statuses.values()
-            if status == "failed"
-        )
-
-    def skipped_count(self) -> int:
-        """Return number of definition+action pairs that were skipped."""
-        return sum(
-            1
-            for action_statuses in self._statuses.values()
-            for status in action_statuses.values()
-            if status == "skipped"
-        )
-
-    def _resolve_git_context(self, working_dir: str) -> str | None:
+    def _resolve_git_context(self, working_dir: str) -> None:
         """Resolve branch and commit from CI env vars or git subprocess."""
         branch = os.environ.get("GITHUB_REF_NAME") or os.environ.get(
             "CI_COMMIT_REF_NAME"
@@ -185,206 +341,682 @@ class SlackStatusBoard:
             except Exception:
                 pass
 
-        parts = []
-        if branch:
-            parts.append(f"Branch: {branch}")
-        if commit:
-            parts.append(f"Commit: {commit}")
-        return "  ".join(parts) if parts else None
+        self._branch = branch or None
+        self._commit = commit or None
 
-    def _status_counts(self) -> dict[str, int]:
-        """Count definition+action pairs by status across all seen actions."""
-        counts: dict[str, int] = {}
-        for action_statuses in self._statuses.values():
-            for action_val in self._seen_actions:
-                st = action_statuses.get(action_val, "pending")
-                counts[st] = counts.get(st, 0) + 1
-        return counts
+    # ------------------------------------------------------------------
+    # classification / aggregation
+    # ------------------------------------------------------------------
+    def _classify(self, rec: DefinitionRecord) -> str:
+        """Classify a definition as failed, running, ok, skipped, or queued."""
+        vals = [rec.statuses.get(a, "pending") for a in self._expected_actions]
+        if "failed" in vals:
+            return "failed"
+        if "running" in vals:
+            return "running"
+        if vals and all(v in TERMINAL_STATUSES for v in vals):
+            return "skipped" if all(v == "skipped" for v in vals) else "ok"
+        return "queued"
 
-    def _banner(self) -> str:
-        """Overall status banner text."""
-        overall = self.overall_status()
-        if overall == "in_progress":
-            return "🟡  *In progress*"
-        if overall == "done":
-            skipped = self.skipped_count()
-            if skipped:
-                return f"✅  *Run complete — {skipped} action(s) skipped*"
-            return "✅  *Run complete — all definitions succeeded*"
-        return f"❌  *Run failed — {self.failed_count()} action(s) errored*"
+    def _buckets(self) -> dict[str, list[DefinitionRecord]]:
+        buckets: dict[str, list[DefinitionRecord]] = {
+            "failed": [],
+            "running": [],
+            "ok": [],
+            "skipped": [],
+            "queued": [],
+        }
+        for rec in self._records.values():
+            buckets[self._classify(rec)].append(rec)
+        buckets["running"].sort(key=lambda r: r.started_at or 0.0)
+        return buckets
 
-    def _build_summary_blocks(self) -> list[dict]:
-        """Compact parent-message blocks: header, git context, banner, counts.
+    @staticmethod
+    def _no_changes(rec: DefinitionRecord) -> bool:
+        """True when a finished definition made (and planned) no changes."""
+        if rec.applied_changes:
+            return False
+        return rec.planned_changes == 0 or rec.statuses.get("apply") == "skipped"
 
-        Kept well under Slack's 50-block limit; the per-definition table lives in
-        threaded detail messages (see _build_detail_chunks).
-        """
-        blocks: list[dict] = []
+    def is_terminal(self) -> bool:
+        """Return True when no definition remains queued or running."""
+        buckets = self._buckets()
+        return not buckets["running"] and not buckets["queued"]
 
-        title = self._title or self._deployment or "Terraform run"
-        header_text = f"🏗️  {title}"
+    def overall_status(self) -> str:
+        """Return 'in_progress', 'failed', or 'done'."""
+        if not self.is_terminal():
+            return "in_progress"
+        if self._buckets()["failed"]:
+            return "failed"
+        return "done"
+
+    def _total_resource_changes(self) -> int:
+        applied = sum(r.applied_changes or 0 for r in self._records.values())
+        if applied:
+            return applied
+        return sum(r.planned_changes or 0 for r in self._records.values())
+
+    def _nouns(self) -> tuple[str, str, str]:
+        return self.ACTION_NOUNS[self._primary_action]
+
+    def _elapsed_text(self) -> str:
+        secs = int(time.monotonic() - self._started_monotonic)
+        if secs < 90:
+            return f"{secs}s"
+        return f"{round(secs / 60)} min"
+
+    def _clock(self, dt: datetime) -> str:
+        return dt.strftime("%H:%M UTC")
+
+    def _run_key(self) -> str:
+        raw = self._run_id or self._deployment or "run"
+        return "tfworker_" + re.sub(r"[^A-Za-z0-9_]", "_", str(raw))
+
+    def _display_name(self) -> str:
+        return self._config.title or self._deployment or "terraform"
+
+    # ------------------------------------------------------------------
+    # block building
+    # ------------------------------------------------------------------
+    def _links_suffix(self) -> str:
+        return "".join(f" · <{lk.url}|{lk.text}>" for lk in self._config.links)
+
+    def _subtitle(self) -> str:
+        parts: list[str] = []
         if self._run_id:
-            header_text += f"  |  run: {self._run_id}"
-        blocks.append(
-            {
-                "type": "header",
-                "text": {"type": "plain_text", "text": header_text, "emoji": True},
-            }
-        )
+            parts.append(f"run `{self._run_id}`")
+        if self._branch:
+            branch = f"branch `{self._branch}`"
+            if self._commit:
+                branch += f" (`{self._commit}`)"
+            parts.append(branch)
+        elif self._commit:
+            parts.append(f"commit `{self._commit}`")
+        if self.overall_status() == "in_progress":
+            parts.append(f"started {self._clock(self._started_wall)}")
+            parts.append(f"updated {self._clock(datetime.now(timezone.utc))}")
+        else:
+            parts.append(f"finished in {self._elapsed_text()}")
+        return " · ".join(parts)
 
-        if self._git_context:
-            blocks.append(
-                {
-                    "type": "context",
-                    "elements": [{"type": "mrkdwn", "text": self._git_context}],
-                }
+    def _status_section(self, buckets: dict) -> dict:
+        _, ing, _ = self._nouns()
+        total = len(self._records)
+        overall = self.overall_status()
+        if overall == "done":
+            text = f":white_check_mark: *Run complete — {total} definitions succeeded*"
+        elif overall == "failed":
+            failed = len(buckets["failed"])
+            text = f":x: *Run failed — {failed} of {total} definitions errored*"
+        else:
+            finished = (
+                len(buckets["failed"]) + len(buckets["ok"]) + len(buckets["skipped"])
             )
-
-        blocks.append(
-            {"type": "section", "text": {"type": "mrkdwn", "text": self._banner()}}
-        )
-
-        counts = self._status_counts()
-        order = [
-            ("running", "🔄"),
-            ("pending", "⏳"),
-            ("changes", "🔵"),
-            ("done", "✅"),
-            ("failed", "❌"),
-            ("skipped", "—"),
-        ]
-        tallies = "  ".join(f"{emoji} {counts[k]}" for k, emoji in order if counts.get(k))
-        summary = f"*{len(self._statuses)}* definition(s)"
-        if tallies:
-            summary += f"   |   {tallies}"
-        summary += "   ·   🧵 per-definition status in thread"
-        blocks.append(
-            {"type": "context", "elements": [{"type": "mrkdwn", "text": summary}]}
-        )
-
-        return blocks
-
-    def _build_detail_chunks(self) -> list[list[dict]]:
-        """Per-definition status table, split into thread messages under the block limit.
-
-        Each chunk is one threaded message: a context header + the column header +
-        up to DETAIL_ROWS_PER_MSG definition rows (<= MAX_BLOCKS blocks total).
-        """
-        if not (self._seen_actions and self._statuses):
-            return []
-
-        action_labels = "  ".join(f"*{a.capitalize()}*" for a in self._seen_actions)
-        header_field = {
+            running = len(buckets["running"])
+            if running:
+                text = (
+                    f":arrows_counterclockwise: *{ing}* — {running} "
+                    f"definition{'s' if running != 1 else ''} running · "
+                    f"{finished} of {total} finished"
+                )
+            else:
+                text = (
+                    f":arrows_counterclockwise: *{ing}* — "
+                    f"{finished} of {total} finished"
+                )
+        return {
             "type": "section",
-            "fields": [
-                {"type": "mrkdwn", "text": "*Definition*"},
-                {"type": "mrkdwn", "text": action_labels},
-            ],
+            "block_id": "run_status",
+            "text": {"type": "mrkdwn", "text": text},
         }
 
-        items = list(self._statuses.items())
-        total = len(items)
-        rows = self.DETAIL_ROWS_PER_MSG
-        n_chunks = max(1, (total + rows - 1) // rows)
+    def _counts_context(self, buckets: dict) -> dict:
+        _, _, past = self._nouns()
+        overall = self.overall_status()
+        ok = [r for r in buckets["ok"] if not self._no_changes(r)]
+        no_change = [r for r in buckets["ok"] if self._no_changes(r)]
+        skipped = len(buckets["skipped"]) + len(no_change)
 
-        chunks: list[list[dict]] = []
-        for i in range(n_chunks):
-            start, end = i * rows, min((i + 1) * rows, total)
-            label = f"Definitions {start + 1}–{end} of {total}"
-            if n_chunks > 1:
-                label += f"   (part {i + 1}/{n_chunks})"
-            blocks: list[dict] = [
-                {"type": "context", "elements": [{"type": "mrkdwn", "text": label}]},
-                header_field,
-            ]
-            for def_name, action_statuses in items[start:end]:
-                emoji_row = "  ".join(
-                    self.STATUS_EMOJI.get(
-                        action_statuses.get(action_val, "pending"), "❓"
-                    )
-                    for action_val in self._seen_actions
+        elements: list[dict] = [
+            {"type": "mrkdwn", "text": f"*{len(self._records)}* definitions"}
+        ]
+        if ok:
+            elements.append(
+                {"type": "mrkdwn", "text": f":white_check_mark: *{len(ok)}* {past}"}
+            )
+        if buckets["failed"]:
+            elements.append(
+                {"type": "mrkdwn", "text": f":x: *{len(buckets['failed'])}* failed"}
+            )
+        if overall == "in_progress":
+            if buckets["running"]:
+                elements.append(
+                    {
+                        "type": "mrkdwn",
+                        "text": f":arrows_counterclockwise: *{len(buckets['running'])}* running",
+                    }
                 )
+            if buckets["queued"]:
+                elements.append(
+                    {
+                        "type": "mrkdwn",
+                        "text": f":hourglass: *{len(buckets['queued'])}* queued",
+                    }
+                )
+        if skipped:
+            elements.append(
+                {"type": "mrkdwn", "text": f":fast_forward: *{skipped}* skipped"}
+            )
+        if overall != "in_progress":
+            changes = self._total_resource_changes()
+            if changes:
+                label = (
+                    "resource changes planned"
+                    if self._primary_action == "plan"
+                    else "resources changed"
+                )
+                elements.append({"type": "mrkdwn", "text": f"{changes} {label}"})
+        return {"type": "context", "block_id": "run_counts", "elements": elements}
+
+    def _links_context(self) -> dict:
+        text = ":thread: per-definition table in thread" + self._links_suffix()
+        return {
+            "type": "context",
+            "block_id": "run_links",
+            "elements": [{"type": "mrkdwn", "text": text}],
+        }
+
+    def _failures_table(self, failed: list[DefinitionRecord]) -> list[dict]:
+        rows: list[list[dict]] = [
+            [
+                {"type": "raw_text", "text": "Definition"},
+                {"type": "raw_text", "text": "Stage"},
+                {"type": "raw_text", "text": "Error"},
+            ]
+        ]
+        for rec in failed[: self.MAX_FAILURE_TABLE_ROWS]:
+            rows.append(
+                [
+                    _rich_text(
+                        [{"type": "text", "text": rec.name, "style": {"code": True}}]
+                    ),
+                    {"type": "raw_text", "text": rec.error_action or "?"},
+                    {
+                        "type": "raw_text",
+                        "text": _truncate(
+                            rec.error_snippet or "unknown error",
+                            self.FAILURE_ERROR_CHARS,
+                        ),
+                    },
+                ]
+            )
+        remainder = len(failed) - self.MAX_FAILURE_TABLE_ROWS
+        more_text = ":thread: full sortable table in thread" + self._links_suffix()
+        if remainder > 0:
+            more_text = f"…and *{remainder} more* failures — " + more_text
+        return [
+            {"type": "divider", "block_id": "verdict_divider"},
+            {
+                "type": "table",
+                "block_id": "failures_table",
+                "column_settings": [
+                    {"is_wrapped": False},
+                    {"align": "center"},
+                    {"is_wrapped": True},
+                ],
+                "rows": rows,
+            },
+            {
+                "type": "context",
+                "block_id": "failures_more",
+                "elements": [{"type": "mrkdwn", "text": more_text}],
+            },
+        ]
+
+    def _build_container(self, buckets: dict) -> dict:
+        overall = self.overall_status()
+        noun, _, _ = self._nouns()
+        children: list[dict] = [
+            self._status_section(buckets),
+            self._counts_context(buckets),
+        ]
+        if overall == "failed":
+            children.extend(self._failures_table(buckets["failed"]))
+        else:
+            children.append(self._links_context())
+
+        block: dict = {
+            "type": "container",
+            "block_id": f"{self._run_key()}_container",
+            "title": {
+                "type": "plain_text",
+                "text": f"{noun} — {self._display_name()}",
+            },
+            "subtitle": {"type": "mrkdwn", "text": self._subtitle()},
+            "child_blocks": children,
+        }
+        # has_header_divider and is_collapsible are mutually exclusive on the
+        # Slack API; final states collapse, running states get the divider.
+        if overall == "in_progress":
+            block["has_header_divider"] = True
+        else:
+            block["is_collapsible"] = True
+        return block
+
+    def _error_task(self, rec: DefinitionRecord) -> dict:
+        task: dict = {
+            "task_id": f"fail_{rec.name}",
+            "title": f"{rec.name} — {rec.error_action or 'run'} failed",
+            "status": "error",
+            "output": _rich_text(
+                [
+                    {
+                        "type": "text",
+                        "text": _truncate(
+                            rec.error_snippet or "unknown error",
+                            self.CARD_ERROR_CHARS,
+                        ),
+                        "style": {"code": True},
+                    }
+                ]
+            ),
+        }
+        template = self._config.definition_log_url_template
+        if template:
+            task["sources"] = [
+                {
+                    "type": "url",
+                    "url": template.format(definition=rec.name),
+                    "text": "full error in Datadog",
+                }
+            ]
+        return task
+
+    def _rollup_complete_task(self, buckets: dict) -> dict | None:
+        _, _, past = self._nouns()
+        ok = [r for r in buckets["ok"] if not self._no_changes(r)]
+        if not ok:
+            return None
+        changes = self._total_resource_changes()
+        label = (
+            "resource changes planned"
+            if self._primary_action == "plan"
+            else "resources changed"
+        )
+        summary = f"{changes} {label}" if changes else "no resource changes"
+        return {
+            "task_id": "rollup_complete",
+            "title": f"{len(ok)} definitions {past} cleanly",
+            "status": "complete",
+            "output": _rich_text(
+                [
+                    {
+                        "type": "text",
+                        "text": f"{summary} · {self._elapsed_text()} elapsed",
+                    }
+                ]
+            ),
+        }
+
+    def _build_plan_block(self, buckets: dict) -> dict | None:
+        overall = self.overall_status()
+        if overall == "failed":
+            # final failures live in the container's table instead
+            return None
+
+        _, ing, _ = self._nouns()
+        tasks: list[dict] = []
+
+        rollup = self._rollup_complete_task(buckets)
+        if rollup:
+            tasks.append(rollup)
+
+        if overall == "done":
+            no_change = [r for r in buckets["ok"] if self._no_changes(r)] + buckets[
+                "skipped"
+            ]
+            if no_change:
+                names = ", ".join(r.name for r in no_change[:10])
+                if len(no_change) > 10:
+                    names += ", …"
+                tasks.append(
+                    {
+                        "task_id": "rollup_skipped",
+                        "title": (
+                            f"{len(no_change)} definitions skipped — "
+                            "no changes planned"
+                        ),
+                        "status": "complete",
+                        "details": _rich_text([{"type": "text", "text": names}]),
+                    }
+                )
+            stored = len([r for r in self._records.values() if r.planned_changes])
+            if self._backend_plans and self._primary_action == "plan" and stored:
+                run_ref = f" keyed by run {self._run_id}" if self._run_id else ""
+                tasks.append(
+                    {
+                        "task_id": "rollup_plans",
+                        "title": "Plans stored in S3",
+                        "status": "complete",
+                        "output": _rich_text(
+                            [
+                                {
+                                    "type": "text",
+                                    "text": f"{stored} plans{run_ref} — "
+                                    "re-applyable via --backend-plans",
+                                }
+                            ]
+                        ),
+                    }
+                )
+        else:
+            for rec in buckets["failed"][: self.MAX_ERROR_CARDS]:
+                tasks.append(self._error_task(rec))
+
+            running = buckets["running"]
+            for rec in running[: self.MAX_NAMED_RUNNING]:
+                task: dict = {
+                    "task_id": f"run_{rec.name}",
+                    "title": f"{rec.name} — {ing.lower()}",
+                    "status": "in_progress",
+                }
+                if rec.plan_line:
+                    task["details"] = _rich_text(
+                        [{"type": "text", "text": rec.plan_line}]
+                    )
+                tasks.append(task)
+            extra_running = running[self.MAX_NAMED_RUNNING :]
+            if extra_running:
+                names = ", ".join(r.name for r in extra_running[:10])
+                if len(extra_running) > 10:
+                    names += ", …"
+                tasks.append(
+                    {
+                        "task_id": "rollup_running",
+                        "title": f"…and {len(extra_running)} more {ing.lower()}",
+                        "status": "in_progress",
+                        "details": _rich_text([{"type": "text", "text": names}]),
+                    }
+                )
+            if buckets["queued"]:
+                queued = buckets["queued"]
+                names = ", ".join(r.name for r in queued[:3])
+                if len(queued) > 3:
+                    names += ", …"
+                tasks.append(
+                    {
+                        "task_id": "rollup_queued",
+                        "title": f"{len(queued)} definitions queued",
+                        "status": "pending",
+                        "details": _rich_text(
+                            [{"type": "text", "text": f"next up: {names}"}]
+                        ),
+                    }
+                )
+
+        if not tasks:
+            return None
+        return {
+            "type": "plan",
+            # Slack recommends a fresh block_id for plan blocks on every update
+            "block_id": f"{self._run_key()}_plan_v{self._seq}",
+            "title": "Run progress",
+            "tasks": tasks,
+        }
+
+    def _build_main_blocks(self) -> list[dict]:
+        buckets = self._buckets()
+        blocks: list[dict] = [self._build_container(buckets)]
+        plan_block = self._build_plan_block(buckets)
+        if plan_block:
+            blocks.append(plan_block)
+        return blocks
+
+    def _status_cell(self, status: str) -> dict:
+        if status == "skipped":
+            return {"type": "raw_text", "text": "—"}
+        return _rich_text(
+            [{"type": "emoji", "name": self.RICH_STATUS_EMOJI.get(status, "question")}]
+        )
+
+    def _build_thread_messages(self) -> list[list[dict]]:
+        """Per-definition data_table messages, chunked under the row limit."""
+        if not (self._records and self._expected_actions):
+            return []
+
+        noun, _, _ = self._nouns()
+        header = [{"type": "raw_text", "text": "Definition"}]
+        header += [
+            {"type": "raw_text", "text": a.capitalize()} for a in self._expected_actions
+        ]
+        header += [
+            {"type": "raw_text", "text": "Changed"},
+            {"type": "raw_text", "text": "Secs"},
+        ]
+
+        data_rows: list[list[dict]] = []
+        for rec in self._records.values():
+            row = [
+                _rich_text(
+                    [{"type": "text", "text": rec.name, "style": {"code": True}}]
+                )
+            ]
+            for action_val in self._expected_actions:
+                row.append(self._status_cell(rec.statuses.get(action_val, "pending")))
+            changed = (
+                rec.applied_changes
+                if rec.applied_changes is not None
+                else rec.planned_changes
+            )
+            # Slack rejects empty raw_text cells ("must be more than 0
+            # characters"); unknown values render as an em dash
+            row.append(
+                {"type": "raw_text", "text": "—" if changed is None else str(changed)}
+            )
+            duration = rec.duration_secs()
+            row.append(
+                {"type": "raw_text", "text": "—" if duration is None else str(duration)}
+            )
+            data_rows.append(row)
+
+        caption = f"Per-definition results — {noun.lower()} {self._display_name()}" + (
+            f" run {self._run_id}" if self._run_id else ""
+        )
+        messages: list[list[dict]] = []
+        size = self.MAX_DATA_TABLE_ROWS
+        n_chunks = max(1, (len(data_rows) + size - 1) // size)
+        for i in range(n_chunks):
+            chunk = data_rows[i * size : (i + 1) * size]
+            blocks: list[dict] = []
+            if i == 0:
+                heading = (
+                    f":clipboard: *Per-definition results* — "
+                    f"{noun.lower()} `{self._display_name()}`"
+                )
+                if self._run_id:
+                    heading += f", run `{self._run_id}`"
+                heading += " (sortable & filterable)"
                 blocks.append(
                     {
                         "type": "section",
-                        "fields": [
-                            {"type": "mrkdwn", "text": f"`{def_name}`"},
-                            {"type": "mrkdwn", "text": emoji_row},
-                        ],
+                        "block_id": "detail_heading",
+                        "text": {"type": "mrkdwn", "text": heading},
                     }
                 )
-            chunks.append(blocks)
-        return chunks
+            blocks.append(
+                {
+                    "type": "data_table",
+                    "block_id": f"{self._run_key()}_table_{i}",
+                    "caption": caption
+                    + (f" (part {i + 1}/{n_chunks})" if n_chunks > 1 else ""),
+                    "page_size": self.DATA_TABLE_PAGE_SIZE,
+                    "row_header_column_index": 0,
+                    "rows": [header] + chunk,
+                }
+            )
+            messages.append(blocks)
+        return messages
 
-    def post_or_update(self, client: WebClient) -> None:
-        """Post/refresh the parent summary message and its threaded detail messages.
+    def _fallback_text(self) -> str:
+        noun, _, _ = self._nouns()
+        buckets = self._buckets()
+        total = len(self._records)
+        overall = self.overall_status()
+        name = self._display_name()
+        if overall == "done":
+            return f"{noun} {name}: complete — {total} definitions succeeded"
+        if overall == "failed":
+            failed = len(buckets["failed"])
+            return f"{noun} {name}: failed — {failed} of {total} definitions errored"
+        finished = len(buckets["failed"]) + len(buckets["ok"]) + len(buckets["skipped"])
+        text = f"{noun} {name}: in progress — {finished} of {total} finished"
+        if buckets["failed"]:
+            text += f", {len(buckets['failed'])} failed"
+        return text
 
-        The board is split across messages to stay under Slack's 50-block limit:
-        a compact parent (summary) message is the thread root, and the
-        per-definition table is posted as one or more threaded replies. Messages
-        whose blocks haven't changed since the last call are not re-sent.
+    # ------------------------------------------------------------------
+    # posting
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_for_compare(blocks: list[dict]) -> list[dict]:
+        """Blocks minus volatile fields, so no-op updates can be skipped.
+
+        The plan block gets a fresh block_id each update and the subtitle
+        carries an "updated HH:MM" clock; neither should force a send.
         """
-        fallback_text = f"Terraform run: {self._deployment or 'unknown'}"
+        normalized = copy.deepcopy(blocks)
+        for block in normalized:
+            if block.get("type") == "plan":
+                block["block_id"] = "PLAN"
+            if block.get("type") == "container" and "subtitle" in block:
+                block["subtitle"] = {}
+        return normalized
 
-        # 1) Parent (summary) message — the thread root.
-        summary_blocks = self._build_summary_blocks()
-        try:
-            if self._ts is None:
-                resp = client.chat_postMessage(
-                    channel=self._channel, blocks=summary_blocks, text=fallback_text
-                )
-                self._ts = resp["ts"]
-                self._channel = resp["channel"]
-                self._parent_blocks_sent = summary_blocks
-            elif summary_blocks != self._parent_blocks_sent:
-                client.chat_update(
-                    channel=self._channel,
-                    ts=self._ts,
-                    blocks=summary_blocks,
-                    text=fallback_text,
-                )
-                self._parent_blocks_sent = summary_blocks
-        except Exception as e:
-            log.error(f"Slack API error updating summary message: {e}")
+    def _call_api(self, method, force: bool, **kwargs):
+        """Invoke a Slack API method, honoring Retry-After on 429.
 
-        # Without a parent message we can't create the thread; try again next call.
-        if self._ts is None:
-            return
-
-        # 2) Threaded detail messages, chunked under the block limit.
-        for i, blocks in enumerate(self._build_detail_chunks()):
+        Non-forced calls drop the update on a 429 (the next flush resends the
+        latest snapshot); forced (terminal) calls sleep and retry.
+        """
+        attempts = 3 if force else 1
+        for attempt in range(attempts):
             try:
-                if i < len(self._detail_ts):
-                    if (
-                        i < len(self._detail_blocks_sent)
-                        and blocks == self._detail_blocks_sent[i]
-                    ):
-                        continue  # unchanged; skip the API call
-                    client.chat_update(
+                return method(**kwargs)
+            except SlackApiError as e:
+                status = getattr(e.response, "status_code", None)
+                if status != 429:
+                    raise
+                retry_after = int(e.response.headers.get("Retry-After", "5"))
+                if attempt + 1 < attempts:
+                    time.sleep(min(retry_after, 30))
+                    continue
+                self._next_update_at = time.monotonic() + max(
+                    retry_after, self._config.update_interval
+                )
+                log.warn(f"Slack rate limited; deferring update {retry_after}s")
+                return None
+        return None
+
+    def post_or_update(self, client: WebClient, force: bool = False) -> None:
+        """Post/refresh the channel message and the threaded detail table.
+
+        Updates are debounced to ``update_interval`` seconds so bursts of
+        definition completions coalesce into one snapshot; ``force`` bypasses
+        the debounce for initial/terminal flushes. Messages whose content has
+        not changed are not re-sent.
+        """
+        with self._lock:
+            if not self._records:
+                return
+            now = time.monotonic()
+            if not force and now < self._next_update_at:
+                return
+            self._seq += 1
+            fallback = self._fallback_text()
+
+            # 1) Channel message — the thread root.
+            main_blocks = self._build_main_blocks()
+            try:
+                if self._ts is None:
+                    resp = self._call_api(
+                        client.chat_postMessage,
+                        force,
                         channel=self._channel,
-                        ts=self._detail_ts[i],
-                        blocks=blocks,
-                        text=fallback_text,
+                        blocks=main_blocks,
+                        text=fallback,
                     )
-                    while len(self._detail_blocks_sent) <= i:
-                        self._detail_blocks_sent.append(None)
-                    self._detail_blocks_sent[i] = blocks
-                else:
-                    resp = client.chat_postMessage(
+                    if resp is not None:
+                        self._ts = resp["ts"]
+                        self._channel = resp["channel"]
+                        self._main_sent = self._normalize_for_compare(main_blocks)
+                elif (
+                    self._normalize_for_compare(main_blocks) != self._main_sent
+                    or self.overall_status() != "in_progress"
+                ):
+                    resp = self._call_api(
+                        client.chat_update,
+                        force,
                         channel=self._channel,
-                        thread_ts=self._ts,
-                        blocks=blocks,
-                        text=fallback_text,
+                        ts=self._ts,
+                        blocks=main_blocks,
+                        text=fallback,
                     )
-                    self._detail_ts.append(resp["ts"])
-                    self._detail_blocks_sent.append(blocks)
+                    if resp is not None:
+                        self._main_sent = self._normalize_for_compare(main_blocks)
             except Exception as e:
-                log.error(f"Slack API error updating detail message {i + 1}: {e}")
+                log.error(f"Slack API error updating run message: {e}")
+
+            # Without a channel message there is no thread; try again next call.
+            if self._ts is None:
+                return
+
+            # 2) Threaded per-definition table.
+            for i, blocks in enumerate(self._build_thread_messages()):
+                try:
+                    if i < len(self._thread_ts):
+                        if (
+                            i < len(self._thread_sent)
+                            and blocks == self._thread_sent[i]
+                        ):
+                            continue
+                        resp = self._call_api(
+                            client.chat_update,
+                            force,
+                            channel=self._channel,
+                            ts=self._thread_ts[i],
+                            blocks=blocks,
+                            text=f"Per-definition results: {self._display_name()}",
+                        )
+                        if resp is not None:
+                            while len(self._thread_sent) <= i:
+                                self._thread_sent.append(None)
+                            self._thread_sent[i] = blocks
+                    else:
+                        resp = self._call_api(
+                            client.chat_postMessage,
+                            force,
+                            channel=self._channel,
+                            thread_ts=self._ts,
+                            blocks=blocks,
+                            text=f"Per-definition results: {self._display_name()}",
+                        )
+                        if resp is not None:
+                            self._thread_ts.append(resp["ts"])
+                            self._thread_sent.append(blocks)
+                except Exception as e:
+                    log.error(f"Slack API error updating detail message {i + 1}: {e}")
+
+            # max() preserves a longer deferral set by a 429 Retry-After
+            self._next_update_at = max(
+                self._next_update_at,
+                time.monotonic() + self._config.update_interval,
+            )
 
 
 @HandlerRegistry.register("slack")
 class SlackHandler(BaseHandler):
-    """Post a live-updating Slack status board for each terraform-worker run."""
+    """Post a live-updating Slack report for each terraform-worker run."""
 
     actions = [
         TerraformAction.INIT,
@@ -398,21 +1030,21 @@ class SlackHandler(BaseHandler):
     def __init__(self, config: SlackConfig) -> None:
         self.config = config
         self._client = WebClient(token=config.resolved_token)
-        run_id = self._get_run_id()
         self._board = SlackStatusBoard(
-            channel=config.channel,
-            title=config.title,
-            run_id=run_id,
+            config=config,
+            run_id=self._get_root_option("run_id"),
+            backend_plans=bool(self._get_root_option("backend_plans")),
         )
         self._ready = True
 
     def is_ready(self) -> bool:
         return self._ready
 
-    def _get_run_id(self) -> str | None:
-        """Retrieve run_id from app state; return None on any failure."""
+    @staticmethod
+    def _get_root_option(attr: str):
+        """Read an option from app state; return None on any failure."""
         try:
-            return click.get_current_context().obj.root_options.run_id
+            return getattr(click.get_current_context().obj.root_options, attr)
         except Exception:
             return None
 
@@ -423,7 +1055,7 @@ class SlackHandler(BaseHandler):
         working_dir: str,
         terraform_options,
     ) -> None:
-        """Pre-populate the board with all definitions and infer expected action columns."""
+        """Pre-populate the board with all definitions and expected actions."""
         try:
             expected_actions = [TerraformAction.INIT]
             if getattr(terraform_options, "plan", False) or getattr(
@@ -437,14 +1069,11 @@ class SlackHandler(BaseHandler):
             if getattr(terraform_options, "destroy", False):
                 expected_actions.append(TerraformAction.DESTROY)
 
+            self._board.set_expected_actions(expected_actions)
             for defn in definitions.values():
                 self._board.ensure_definition(defn.name, deployment, working_dir)
-                for action in expected_actions:
-                    action_val = action.value
-                    if action_val not in self._board._statuses[defn.name]:
-                        self._board.mark(defn.name, action, "pending")
 
-            self._board.post_or_update(self._client)
+            self._board.post_or_update(self._client, force=True)
         except Exception as e:
             log.error(f"SlackHandler.setup error: {e}")
 
@@ -455,12 +1084,15 @@ class SlackHandler(BaseHandler):
     ) -> None:
         """Finalize the board; resolve any unfinished statuses."""
         try:
-            for action_statuses in self._board._statuses.values():
-                for action_val in list(action_statuses):
-                    if action_statuses[action_val] in ("running", "pending"):
-                        action_statuses[action_val] = "skipped"
+            for rec in self._board._records.values():
+                for action_val in self._board._expected_actions:
+                    if rec.statuses.get(action_val, "pending") in (
+                        "pending",
+                        "running",
+                    ):
+                        rec.statuses[action_val] = "skipped"
 
-            self._board.post_or_update(self._client)
+            self._board.post_or_update(self._client, force=True)
         except Exception as e:
             log.error(f"SlackHandler.teardown error: {e}")
 
@@ -489,8 +1121,20 @@ class SlackHandler(BaseHandler):
             else:
                 status = "failed"
             self._board.mark(definition.name, action, status)
+            self._board.record_result(
+                definition.name, action, result, failed=(status == "failed")
+            )
+            # a clean plan with no changes means apply will be skipped; mark it
+            # now so finished counts stay accurate during the run
+            if (
+                action == TerraformAction.PLAN
+                and status == "done"
+                and "apply" in self._board._expected_actions
+            ):
+                self._board.mark(definition.name, TerraformAction.APPLY, "skipped")
             self._board.post_or_update(self._client)
 
         elif stage == TerraformStage.ERROR:
             self._board.mark(definition.name, action, "failed")
+            self._board.record_result(definition.name, action, result, failed=True)
             self._board.post_or_update(self._client)

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -29,7 +29,8 @@ Notes on Slack API behavior this module encodes (all confirmed live):
 - ``has_header_divider`` and ``is_collapsible`` on a container are mutually
   exclusive at post/update time.
 - ``data_table`` cells reject ``raw_number``; numeric columns use ``raw_text``.
-- ``plan`` blocks should get a fresh ``block_id`` on every ``chat.update``.
+- ``plan`` blocks keep a stable ``block_id`` across updates: a fresh id makes
+  Slack treat the block as new and reset its expanded/collapsed state.
 - ``blocks.validate`` accepts payloads the message APIs reject; only real
   ``chat.postMessage``/``chat.update`` calls prove a payload.
 - The bot token only has ``chat:write``/``chat:write.public`` so every posted
@@ -217,7 +218,6 @@ class SlackStatusBoard:
 
         self._lock = threading.RLock()
         self._sending = False
-        self._seq = 0
         self._next_update_at = 0.0
         self._ts: str | None = None
         self._thread_ts: list[str] = []
@@ -424,6 +424,24 @@ class SlackStatusBoard:
             return "no_changes"
         return "ok"
 
+    @staticmethod
+    def _running_action(rec: DefinitionRecord) -> str | None:
+        for action_val in rec.expected:
+            if rec.statuses.get(action_val) == "running":
+                return action_val
+        return None
+
+    def _running_verb(self, recs: list[DefinitionRecord]) -> str:
+        """Verb for what these definitions are actually doing right now.
+
+        The run's primary verb would be wrong here: during the parallel init
+        phase a plan run would label everything "planning".
+        """
+        actions = {self._running_action(r) for r in recs} - {None}
+        if len(actions) == 1:
+            return self.ACTION_NOUNS[actions.pop()][1].lower()
+        return "running"
+
     def _buckets(self) -> dict[str, list[DefinitionRecord]]:
         buckets: dict[str, list[DefinitionRecord]] = {
             "failed": [],
@@ -525,8 +543,9 @@ class SlackStatusBoard:
             )
             running = len(buckets["running"])
             if running:
+                phase = self._running_verb(buckets["running"]).capitalize()
                 text = (
-                    f":arrows_counterclockwise: *{ing}* — {running} "
+                    f":arrows_counterclockwise: *{phase}* — {running} "
                     f"definition{'s' if running != 1 else ''} running · "
                     f"{finished} of {total} finished"
                 )
@@ -754,7 +773,6 @@ class SlackStatusBoard:
             # final failures live in the container's table instead
             return None
 
-        _, ing, _ = self._nouns()
         tasks: list[dict] = []
 
         rollup = self._rollup_complete_task(buckets)
@@ -824,7 +842,7 @@ class SlackStatusBoard:
             for rec in running[: self.MAX_NAMED_RUNNING]:
                 task: dict = {
                     "task_id": f"run_{rec.name}",
-                    "title": f"{rec.name} — {ing.lower()}",
+                    "title": f"{rec.name} — {self._running_verb([rec])}",
                     "status": "in_progress",
                 }
                 if rec.plan_line:
@@ -837,7 +855,10 @@ class SlackStatusBoard:
                 tasks.append(
                     {
                         "task_id": "rollup_running",
-                        "title": f"…and {len(extra_running)} more {ing.lower()}",
+                        "title": (
+                            f"…and {len(extra_running)} more "
+                            f"{self._running_verb(extra_running)}"
+                        ),
                         "status": "in_progress",
                         "details": _rich_text(
                             [{"type": "text", "text": self._name_list(extra_running)}]
@@ -866,8 +887,10 @@ class SlackStatusBoard:
             return None
         return {
             "type": "plan",
-            # Slack recommends a fresh block_id for plan blocks on every update
-            "block_id": f"{self._run_key()}_plan_v{self._seq}",
+            # stable block_id: a fresh one per update makes Slack treat the
+            # block as new and reset its expanded/collapsed state, collapsing
+            # the feed under a watching user
+            "block_id": f"{self._run_key()}_plan",
             "title": "Run progress",
             "tasks": tasks,
         }
@@ -1034,13 +1057,11 @@ class SlackStatusBoard:
     def _normalize_for_compare(blocks: list[dict]) -> list[dict]:
         """Blocks minus volatile fields, so no-op updates can be skipped.
 
-        The plan block gets a fresh block_id each update and the subtitle
-        carries an "updated HH:MM" clock; neither should force a send.
+        The container subtitle carries an "updated HH:MM" clock, which alone
+        should not force a send.
         """
         normalized = copy.deepcopy(blocks)
         for block in normalized:
-            if block.get("type") == "plan":
-                block["block_id"] = "PLAN"
             if block.get("type") == "container" and "subtitle" in block:
                 block["subtitle"] = {}
         return normalized
@@ -1090,7 +1111,6 @@ class SlackStatusBoard:
             if not force and (now < self._next_update_at or self._sending):
                 return
             self._sending = True
-            self._seq += 1
             fallback = self._fallback_text()
             final = self.overall_status() != "in_progress"
             main_blocks = self._build_main_blocks()

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -23,6 +23,8 @@ Example configuration::
         # replaced with the definition name
         definition_log_url_template: "https://app.datadoghq.com/logs?query=service%3Aneptune-executor%20%40definition%3A{definition}"
         update_interval: 4.0       # min seconds between Slack updates
+        timezone: "America/Chicago"  # for timestamp fallback text; live
+                                     # timestamps render in the viewer's tz
 
 Notes on Slack API behavior this module encodes (all confirmed live):
 
@@ -45,6 +47,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Union
+from zoneinfo import ZoneInfo
 
 import click
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
@@ -83,6 +86,7 @@ class SlackConfig(BaseModel):
     links: list[SlackLink] = Field(default_factory=list)
     definition_log_url_template: str | None = None
     update_interval: float = Field(default=4.0, ge=0.0)
+    timezone: str = "America/Chicago"
 
     _resolved_token: str = PrivateAttr(default="")
 
@@ -180,14 +184,15 @@ class SlackStatusBoard:
     }
     ACTION_ORDER: list[str] = ["init", "plan", "apply", "destroy"]
     ACTION_NOUNS: dict[str, tuple[str, str, str]] = {
-        # action -> (noun, present participle, past tense)
-        "plan": ("Plan", "Planning", "planned"),
+        # action -> (noun, present participle, outcome phrase)
+        # plan's outcome reads "N with changes", complementing "N no changes"
+        "plan": ("Plan", "Planning", "with changes"),
         "apply": ("Apply", "Applying", "applied"),
         "destroy": ("Destroy", "Destroying", "destroyed"),
         "init": ("Init", "Initializing", "initialized"),
     }
     MAX_ERROR_CARDS: int = 5
-    MAX_NAMED_RUNNING: int = 2
+    MAX_NAMED_RUNNING: int = 10
     MAX_FAILURE_TABLE_ROWS: int = 5
     MAX_DATA_TABLE_ROWS: int = 200
     MAX_DATA_TABLE_CHARS: int = 18000
@@ -485,7 +490,12 @@ class SlackStatusBoard:
         return f"{round(secs / 60)} min"
 
     def _clock(self, dt: datetime) -> str:
-        return dt.strftime("%H:%M UTC")
+        """Fallback clock text in the configured timezone (UTC if unknown)."""
+        try:
+            dt = dt.astimezone(ZoneInfo(self._config.timezone))
+        except Exception:
+            pass
+        return dt.strftime("%H:%M %Z")
 
     def _run_key(self) -> str:
         raw = self._run_id or self._deployment or "run"
@@ -749,8 +759,8 @@ class SlackStatusBoard:
         return names
 
     def _rollup_complete_task(self, buckets: dict) -> dict | None:
-        _, _, past = self._nouns()
-        ok = len(buckets["ok"])
+        _, _, outcome = self._nouns()
+        ok = buckets["ok"]
         if not ok:
             return None
         changes = self._total_resource_changes()
@@ -762,8 +772,9 @@ class SlackStatusBoard:
         summary = f"{changes} {label}" if changes else "no resource changes"
         return {
             "task_id": "rollup_complete",
-            "title": f"{ok} definitions {past} cleanly",
+            "title": f"{len(ok)} definitions {outcome}",
             "status": "complete",
+            "details": _rich_text([{"type": "text", "text": self._name_list(ok)}]),
             "output": _rich_text(
                 [
                     {
@@ -775,12 +786,18 @@ class SlackStatusBoard:
         }
 
     def _build_plan_block(self, buckets: dict) -> dict | None:
+        """The "Run Details" feed: failures, then outcome rollups (with
+        changes / no changes / skipped), then per-definition running tasks
+        and the queue while the run is live."""
         overall = self.overall_status()
         if overall == "failed":
             # final failures live in the container's table instead
             return None
 
         tasks: list[dict] = []
+
+        for rec in buckets["failed"][: self.MAX_ERROR_CARDS]:
+            tasks.append(self._error_task(rec))
 
         rollup = self._rollup_complete_task(buckets)
         if rollup:
@@ -805,24 +822,24 @@ class SlackStatusBoard:
                     ),
                 }
             )
+        if buckets["skipped"]:
+            tasks.append(
+                {
+                    "task_id": "rollup_skipped",
+                    "title": f"{len(buckets['skipped'])} definitions skipped — not run",
+                    "status": "complete",
+                    "details": _rich_text(
+                        [
+                            {
+                                "type": "text",
+                                "text": self._name_list(buckets["skipped"]),
+                            }
+                        ]
+                    ),
+                }
+            )
 
         if overall == "done":
-            if buckets["skipped"]:
-                tasks.append(
-                    {
-                        "task_id": "rollup_skipped",
-                        "title": f"{len(buckets['skipped'])} definitions skipped — not run",
-                        "status": "complete",
-                        "details": _rich_text(
-                            [
-                                {
-                                    "type": "text",
-                                    "text": self._name_list(buckets["skipped"]),
-                                }
-                            ]
-                        ),
-                    }
-                )
             stored = len([r for r in self._records.values() if r.planned_changes])
             if self._backend_plans and self._primary_action == "plan" and stored:
                 run_ref = f" keyed by run {self._run_id}" if self._run_id else ""
@@ -843,9 +860,8 @@ class SlackStatusBoard:
                     }
                 )
         else:
-            for rec in buckets["failed"][: self.MAX_ERROR_CARDS]:
-                tasks.append(self._error_task(rec))
-
+            # every running definition gets its own task showing the step it
+            # is on; the rollup only absorbs overflow past MAX_NAMED_RUNNING
             running = buckets["running"]
             for rec in running[: self.MAX_NAMED_RUNNING]:
                 task: dict = {
@@ -899,7 +915,7 @@ class SlackStatusBoard:
             # block as new and reset its expanded/collapsed state, collapsing
             # the feed under a watching user
             "block_id": f"{self._run_key()}_plan",
-            "title": "Run progress",
+            "title": "📝 Run Details",
             "tasks": tasks,
         }
 

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -500,6 +500,11 @@ class SlackStatusBoard:
     def _links_suffix(self) -> str:
         return "".join(f" · <{lk.url}|{lk.text}>" for lk in self._config.links)
 
+    def _slack_date(self, dt: datetime, token: str) -> str:
+        """Slack date mrkdwn: rendered in the viewer's local time (or as a
+        relative "N minutes ago" for {ago}), with a UTC clock fallback."""
+        return f"<!date^{int(dt.timestamp())}^{{{token}}}|{self._clock(dt)}>"
+
     def _subtitle(self) -> str:
         parts: list[str] = []
         if self._run_id:
@@ -512,8 +517,10 @@ class SlackStatusBoard:
         elif self._commit:
             parts.append(f"commit `{self._commit}`")
         if self.overall_status() == "in_progress":
-            parts.append(f"started {self._clock(self._started_wall)}")
-            parts.append(f"updated {self._clock(datetime.now(timezone.utc))}")
+            parts.append(f"started {self._slack_date(self._started_wall, 'time')}")
+            parts.append(
+                f"updated {self._slack_date(datetime.now(timezone.utc), 'ago')}"
+            )
         else:
             parts.append(f"finished in {self._elapsed_text()}")
         return " · ".join(parts)

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -377,21 +377,36 @@ class SlackStatusBoard:
     # classification / aggregation
     # ------------------------------------------------------------------
     def _classify(self, rec: DefinitionRecord) -> str:
-        """Classify a definition as failed, running, ok, skipped, or queued."""
+        """Classify a definition as failed, running, ok, no_changes, skipped, or queued.
+
+        "no_changes" means the plan ran and found nothing to do; "skipped" is
+        reserved for definitions whose work never ran at all (e.g. an aborted
+        run resolved by teardown) — conflating them would misreport clean
+        plans as not having run.
+        """
         vals = [rec.statuses.get(a, "pending") for a in self._expected_actions]
         if "failed" in vals:
             return "failed"
         if "running" in vals:
             return "running"
-        if vals and all(v in TERMINAL_STATUSES for v in vals):
-            return "skipped" if all(v == "skipped" for v in vals) else "ok"
-        return "queued"
+        if not (vals and all(v in TERMINAL_STATUSES for v in vals)):
+            return "queued"
+        if all(v == "skipped" for v in vals):
+            return "skipped"
+        if "plan" in self._expected_actions and rec.statuses.get("plan") == "skipped":
+            return "skipped"
+        if not rec.applied_changes and (
+            rec.planned_changes == 0 or rec.statuses.get("apply") == "skipped"
+        ):
+            return "no_changes"
+        return "ok"
 
     def _buckets(self) -> dict[str, list[DefinitionRecord]]:
         buckets: dict[str, list[DefinitionRecord]] = {
             "failed": [],
             "running": [],
             "ok": [],
+            "no_changes": [],
             "skipped": [],
             "queued": [],
         }
@@ -399,13 +414,6 @@ class SlackStatusBoard:
             buckets[self._classify(rec)].append(rec)
         buckets["running"].sort(key=lambda r: r.started_at or 0.0)
         return buckets
-
-    @staticmethod
-    def _no_changes(rec: DefinitionRecord) -> bool:
-        """True when a finished definition made (and planned) no changes."""
-        if rec.applied_changes:
-            return False
-        return rec.planned_changes == 0 or rec.statuses.get("apply") == "skipped"
 
     def is_terminal(self) -> bool:
         """Return True when no definition remains queued or running."""
@@ -469,12 +477,6 @@ class SlackStatusBoard:
             parts.append(f"finished in {self._elapsed_text()}")
         return " · ".join(parts)
 
-    def _outcome_counts(self, buckets: dict) -> tuple[int, int]:
-        """(definitions that did work, definitions skipped or without changes)."""
-        ok = [r for r in buckets["ok"] if not self._no_changes(r)]
-        skipped = len(buckets["ok"]) - len(ok) + len(buckets["skipped"])
-        return len(ok), skipped
-
     def _status_section(self, buckets: dict) -> dict:
         _, ing, past = self._nouns()
         total = len(self._records)
@@ -482,17 +484,21 @@ class SlackStatusBoard:
         if overall == "done":
             # report real outcomes: teardown bulk-skips definitions an aborted
             # run never reached, so "N definitions succeeded" would mislead
-            ok, skipped = self._outcome_counts(buckets)
-            text = f":white_check_mark: *Run complete — {ok} {past}"
-            if skipped:
-                text += f", {skipped} skipped"
-            text += "*"
+            parts = [f"{len(buckets['ok'])} {past}"]
+            if buckets["no_changes"]:
+                parts.append(f"{len(buckets['no_changes'])} no changes")
+            if buckets["skipped"]:
+                parts.append(f"{len(buckets['skipped'])} skipped")
+            text = f":white_check_mark: *Run complete — {', '.join(parts)}*"
         elif overall == "failed":
             failed = len(buckets["failed"])
             text = f":x: *Run failed — {failed} of {total} definitions errored*"
         else:
             finished = (
-                len(buckets["failed"]) + len(buckets["ok"]) + len(buckets["skipped"])
+                len(buckets["failed"])
+                + len(buckets["ok"])
+                + len(buckets["no_changes"])
+                + len(buckets["skipped"])
             )
             running = len(buckets["running"])
             if running:
@@ -515,14 +521,16 @@ class SlackStatusBoard:
     def _counts_context(self, buckets: dict) -> dict:
         _, _, past = self._nouns()
         overall = self.overall_status()
-        ok, skipped = self._outcome_counts(buckets)
 
         elements: list[dict] = [
             {"type": "mrkdwn", "text": f"*{len(self._records)}* definitions"}
         ]
-        if ok:
+        if buckets["ok"]:
             elements.append(
-                {"type": "mrkdwn", "text": f":white_check_mark: *{ok}* {past}"}
+                {
+                    "type": "mrkdwn",
+                    "text": f":white_check_mark: *{len(buckets['ok'])}* {past}",
+                }
             )
         if buckets["failed"]:
             elements.append(
@@ -543,9 +551,19 @@ class SlackStatusBoard:
                         "text": f":hourglass: *{len(buckets['queued'])}* queued",
                     }
                 )
-        if skipped:
+        if buckets["no_changes"]:
             elements.append(
-                {"type": "mrkdwn", "text": f":fast_forward: *{skipped}* skipped"}
+                {
+                    "type": "mrkdwn",
+                    "text": f":heavy_minus_sign: *{len(buckets['no_changes'])}* no changes",
+                }
+            )
+        if buckets["skipped"]:
+            elements.append(
+                {
+                    "type": "mrkdwn",
+                    "text": f":fast_forward: *{len(buckets['skipped'])}* skipped",
+                }
             )
         if overall != "in_progress":
             changes = self._total_resource_changes()
@@ -683,7 +701,7 @@ class SlackStatusBoard:
 
     def _rollup_complete_task(self, buckets: dict) -> dict | None:
         _, _, past = self._nouns()
-        ok, _ = self._outcome_counts(buckets)
+        ok = len(buckets["ok"])
         if not ok:
             return None
         changes = self._total_resource_changes()
@@ -721,20 +739,38 @@ class SlackStatusBoard:
             tasks.append(rollup)
 
         if overall == "done":
-            no_change = [r for r in buckets["ok"] if self._no_changes(r)] + buckets[
-                "skipped"
-            ]
-            if no_change:
+            if buckets["no_changes"]:
                 tasks.append(
                     {
-                        "task_id": "rollup_skipped",
+                        "task_id": "rollup_no_changes",
                         "title": (
-                            f"{len(no_change)} definitions skipped — "
-                            "no changes planned"
+                            f"{len(buckets['no_changes'])} definitions with "
+                            "no changes"
                         ),
                         "status": "complete",
                         "details": _rich_text(
-                            [{"type": "text", "text": self._name_list(no_change)}]
+                            [
+                                {
+                                    "type": "text",
+                                    "text": self._name_list(buckets["no_changes"]),
+                                }
+                            ]
+                        ),
+                    }
+                )
+            if buckets["skipped"]:
+                tasks.append(
+                    {
+                        "task_id": "rollup_skipped",
+                        "title": f"{len(buckets['skipped'])} definitions skipped — not run",
+                        "status": "complete",
+                        "details": _rich_text(
+                            [
+                                {
+                                    "type": "text",
+                                    "text": self._name_list(buckets["skipped"]),
+                                }
+                            ]
                         ),
                     }
                 )
@@ -849,7 +885,7 @@ class SlackStatusBoard:
         ]
         header += [
             {"type": "raw_text", "text": "Changed"},
-            {"type": "raw_text", "text": "Secs"},
+            {"type": "raw_text", "text": "Ran (s)"},
         ]
 
         data_rows: list[list[dict]] = []
@@ -873,7 +909,10 @@ class SlackStatusBoard:
             )
             duration = rec.duration_secs()
             row.append(
-                {"type": "raw_text", "text": "—" if duration is None else str(duration)}
+                {
+                    "type": "raw_text",
+                    "text": "—" if duration is None else f"{duration}s",
+                }
             )
             data_rows.append(row)
 
@@ -935,15 +974,21 @@ class SlackStatusBoard:
         overall = self.overall_status()
         name = self._display_name()
         if overall == "done":
-            ok, skipped = self._outcome_counts(buckets)
-            text = f"{noun} {name}: complete — {ok} {past}"
-            if skipped:
-                text += f", {skipped} skipped"
-            return text
+            parts = [f"{len(buckets['ok'])} {past}"]
+            if buckets["no_changes"]:
+                parts.append(f"{len(buckets['no_changes'])} no changes")
+            if buckets["skipped"]:
+                parts.append(f"{len(buckets['skipped'])} skipped")
+            return f"{noun} {name}: complete — {', '.join(parts)}"
         if overall == "failed":
             failed = len(buckets["failed"])
             return f"{noun} {name}: failed — {failed} of {total} definitions errored"
-        finished = len(buckets["failed"]) + len(buckets["ok"]) + len(buckets["skipped"])
+        finished = (
+            len(buckets["failed"])
+            + len(buckets["ok"])
+            + len(buckets["no_changes"])
+            + len(buckets["skipped"])
+        )
         text = f"{noun} {name}: in progress — {finished} of {total} finished"
         if buckets["failed"]:
             text += f", {len(buckets['failed'])} failed"

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -43,7 +43,7 @@ import subprocess
 import threading
 import time
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 import click
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
@@ -125,7 +125,8 @@ class DefinitionRecord:
         "name",
         "statuses",
         "started_at",
-        "finished_at",
+        "action_started",
+        "work_secs",
         "plan_line",
         "planned_changes",
         "applied_changes",
@@ -137,7 +138,8 @@ class DefinitionRecord:
         self.name = name
         self.statuses: dict[str, str] = {}
         self.started_at: float | None = None
-        self.finished_at: float | None = None
+        self.action_started: dict[str, float] = {}
+        self.work_secs: float = 0.0
         self.plan_line: str | None = None
         self.planned_changes: int | None = None
         self.applied_changes: int | None = None
@@ -145,9 +147,13 @@ class DefinitionRecord:
         self.error_snippet: str | None = None
 
     def duration_secs(self) -> int | None:
-        if self.started_at is None or self.finished_at is None:
-            return None
-        return int(self.finished_at - self.started_at)
+        """Seconds spent actually running actions for this definition.
+
+        Summed per action rather than start-to-finish: all inits run (in
+        parallel) long before a definition's serial plan/apply, so wall time
+        would report near-whole-run durations for every definition.
+        """
+        return int(self.work_secs) if self.work_secs else None
 
 
 class SlackStatusBoard:
@@ -179,6 +185,7 @@ class SlackStatusBoard:
     MAX_NAMED_RUNNING: int = 2
     MAX_FAILURE_TABLE_ROWS: int = 5
     MAX_DATA_TABLE_ROWS: int = 200
+    MAX_DATA_TABLE_CHARS: int = 18000
     DATA_TABLE_PAGE_SIZE: int = 15
     FAILURE_ERROR_CHARS: int = 80
     CARD_ERROR_CHARS: int = 200
@@ -205,11 +212,12 @@ class SlackStatusBoard:
         self._started_wall = datetime.now(timezone.utc)
 
         self._lock = threading.RLock()
+        self._sending = False
         self._seq = 0
         self._next_update_at = 0.0
         self._ts: str | None = None
         self._thread_ts: list[str] = []
-        self._main_sent: Union[list, None] = None
+        self._main_sent: list | None = None
         self._thread_sent: list[list] = []
 
     # ------------------------------------------------------------------
@@ -251,19 +259,18 @@ class SlackStatusBoard:
             rec = self._records[definition_name]
             rec.statuses[action_val] = status
             now = time.monotonic()
-            if status == "running" and rec.started_at is None:
-                rec.started_at = now
-            if status in TERMINAL_STATUSES and self._classify(rec) not in (
-                "running",
-                "queued",
-            ):
-                rec.finished_at = now
+            if status == "running":
+                if rec.started_at is None:
+                    rec.started_at = now
+                rec.action_started[action_val] = now
+            elif status in TERMINAL_STATUSES and action_val in rec.action_started:
+                rec.work_secs += now - rec.action_started.pop(action_val)
 
     def record_result(
         self,
         definition_name: str,
         action: TerraformAction,
-        result: Optional["TerraformResult"],
+        result: Union["TerraformResult", None],
         failed: bool = False,
     ) -> None:
         """Capture plan/apply output details or an error snippet for a definition."""
@@ -273,7 +280,14 @@ class SlackStatusBoard:
             rec = self._records.get(definition_name)
             if rec is None:
                 return
-            text = _ANSI_RE.sub("", f"{result.stdout_str}\n{result.stderr_str}")
+            # errors="replace": providers can emit non-UTF-8 bytes, and a decode
+            # error here must not take down the run
+            text = _ANSI_RE.sub(
+                "",
+                result.stdout.decode(errors="replace")
+                + "\n"
+                + result.stderr.decode(errors="replace"),
+            )
             if failed:
                 rec.error_action = action.value
                 rec.error_snippet = self._extract_error(text)
@@ -293,6 +307,21 @@ class SlackStatusBoard:
                     rec.applied_changes = sum(
                         int(n) for n in _APPLY_COUNT_RE.findall(match.group(0))
                     )
+
+    def expects(self, action: TerraformAction) -> bool:
+        """Return True when the run is expected to perform the given action."""
+        return action.value in self._expected_actions
+
+    def finalize(self) -> None:
+        """Resolve statuses left pending/running as skipped (run over or aborted)."""
+        with self._lock:
+            for rec in self._records.values():
+                for action_val in self._expected_actions:
+                    if rec.statuses.get(action_val, "pending") in (
+                        "pending",
+                        "running",
+                    ):
+                        rec.statuses[action_val] = "skipped"
 
     @staticmethod
     def _extract_error(text: str) -> str:
@@ -440,12 +469,24 @@ class SlackStatusBoard:
             parts.append(f"finished in {self._elapsed_text()}")
         return " · ".join(parts)
 
+    def _outcome_counts(self, buckets: dict) -> tuple[int, int]:
+        """(definitions that did work, definitions skipped or without changes)."""
+        ok = [r for r in buckets["ok"] if not self._no_changes(r)]
+        skipped = len(buckets["ok"]) - len(ok) + len(buckets["skipped"])
+        return len(ok), skipped
+
     def _status_section(self, buckets: dict) -> dict:
-        _, ing, _ = self._nouns()
+        _, ing, past = self._nouns()
         total = len(self._records)
         overall = self.overall_status()
         if overall == "done":
-            text = f":white_check_mark: *Run complete — {total} definitions succeeded*"
+            # report real outcomes: teardown bulk-skips definitions an aborted
+            # run never reached, so "N definitions succeeded" would mislead
+            ok, skipped = self._outcome_counts(buckets)
+            text = f":white_check_mark: *Run complete — {ok} {past}"
+            if skipped:
+                text += f", {skipped} skipped"
+            text += "*"
         elif overall == "failed":
             failed = len(buckets["failed"])
             text = f":x: *Run failed — {failed} of {total} definitions errored*"
@@ -474,16 +515,14 @@ class SlackStatusBoard:
     def _counts_context(self, buckets: dict) -> dict:
         _, _, past = self._nouns()
         overall = self.overall_status()
-        ok = [r for r in buckets["ok"] if not self._no_changes(r)]
-        no_change = [r for r in buckets["ok"] if self._no_changes(r)]
-        skipped = len(buckets["skipped"]) + len(no_change)
+        ok, skipped = self._outcome_counts(buckets)
 
         elements: list[dict] = [
             {"type": "mrkdwn", "text": f"*{len(self._records)}* definitions"}
         ]
         if ok:
             elements.append(
-                {"type": "mrkdwn", "text": f":white_check_mark: *{len(ok)}* {past}"}
+                {"type": "mrkdwn", "text": f":white_check_mark: *{ok}* {past}"}
             )
         if buckets["failed"]:
             elements.append(
@@ -627,15 +666,24 @@ class SlackStatusBoard:
             task["sources"] = [
                 {
                     "type": "url",
-                    "url": template.format(definition=rec.name),
+                    # not str.format(): URLs legitimately contain braces, which
+                    # would raise and take down the run
+                    "url": template.replace("{definition}", rec.name),
                     "text": "full error in Datadog",
                 }
             ]
         return task
 
+    @staticmethod
+    def _name_list(recs: list[DefinitionRecord], cap: int = 10) -> str:
+        names = ", ".join(r.name for r in recs[:cap])
+        if len(recs) > cap:
+            names += ", …"
+        return names
+
     def _rollup_complete_task(self, buckets: dict) -> dict | None:
         _, _, past = self._nouns()
-        ok = [r for r in buckets["ok"] if not self._no_changes(r)]
+        ok, _ = self._outcome_counts(buckets)
         if not ok:
             return None
         changes = self._total_resource_changes()
@@ -647,7 +695,7 @@ class SlackStatusBoard:
         summary = f"{changes} {label}" if changes else "no resource changes"
         return {
             "task_id": "rollup_complete",
-            "title": f"{len(ok)} definitions {past} cleanly",
+            "title": f"{ok} definitions {past} cleanly",
             "status": "complete",
             "output": _rich_text(
                 [
@@ -677,9 +725,6 @@ class SlackStatusBoard:
                 "skipped"
             ]
             if no_change:
-                names = ", ".join(r.name for r in no_change[:10])
-                if len(no_change) > 10:
-                    names += ", …"
                 tasks.append(
                     {
                         "task_id": "rollup_skipped",
@@ -688,7 +733,9 @@ class SlackStatusBoard:
                             "no changes planned"
                         ),
                         "status": "complete",
-                        "details": _rich_text([{"type": "text", "text": names}]),
+                        "details": _rich_text(
+                            [{"type": "text", "text": self._name_list(no_change)}]
+                        ),
                     }
                 )
             stored = len([r for r in self._records.values() if r.planned_changes])
@@ -728,29 +775,30 @@ class SlackStatusBoard:
                 tasks.append(task)
             extra_running = running[self.MAX_NAMED_RUNNING :]
             if extra_running:
-                names = ", ".join(r.name for r in extra_running[:10])
-                if len(extra_running) > 10:
-                    names += ", …"
                 tasks.append(
                     {
                         "task_id": "rollup_running",
                         "title": f"…and {len(extra_running)} more {ing.lower()}",
                         "status": "in_progress",
-                        "details": _rich_text([{"type": "text", "text": names}]),
+                        "details": _rich_text(
+                            [{"type": "text", "text": self._name_list(extra_running)}]
+                        ),
                     }
                 )
             if buckets["queued"]:
                 queued = buckets["queued"]
-                names = ", ".join(r.name for r in queued[:3])
-                if len(queued) > 3:
-                    names += ", …"
                 tasks.append(
                     {
                         "task_id": "rollup_queued",
                         "title": f"{len(queued)} definitions queued",
                         "status": "pending",
                         "details": _rich_text(
-                            [{"type": "text", "text": f"next up: {names}"}]
+                            [
+                                {
+                                    "type": "text",
+                                    "text": f"next up: {self._name_list(queued, cap=3)}",
+                                }
+                            ]
                         ),
                     }
                 )
@@ -772,6 +820,15 @@ class SlackStatusBoard:
         if plan_block:
             blocks.append(plan_block)
         return blocks
+
+    @staticmethod
+    def _cell_chars(cell: dict) -> int:
+        if cell["type"] == "raw_text":
+            return len(cell["text"])
+        return sum(
+            len(el.get("text") or el.get("name") or "")
+            for el in cell["elements"][0]["elements"]
+        )
 
     def _status_cell(self, status: str) -> dict:
         if status == "skipped":
@@ -823,11 +880,24 @@ class SlackStatusBoard:
         caption = f"Per-definition results — {noun.lower()} {self._display_name()}" + (
             f" run {self._run_id}" if self._run_id else ""
         )
+        # chunk on both the 200-row limit and Slack's 20k-char aggregate cell
+        # limit per message (long definition names can hit chars before rows)
+        chunks: list[list[list[dict]]] = [[]]
+        chars = 0
+        for row in data_rows:
+            row_chars = sum(self._cell_chars(cell) for cell in row)
+            if chunks[-1] and (
+                len(chunks[-1]) >= self.MAX_DATA_TABLE_ROWS
+                or chars + row_chars > self.MAX_DATA_TABLE_CHARS
+            ):
+                chunks.append([])
+                chars = 0
+            chunks[-1].append(row)
+            chars += row_chars
+
         messages: list[list[dict]] = []
-        size = self.MAX_DATA_TABLE_ROWS
-        n_chunks = max(1, (len(data_rows) + size - 1) // size)
-        for i in range(n_chunks):
-            chunk = data_rows[i * size : (i + 1) * size]
+        n_chunks = len(chunks)
+        for i, chunk in enumerate(chunks):
             blocks: list[dict] = []
             if i == 0:
                 heading = (
@@ -859,13 +929,17 @@ class SlackStatusBoard:
         return messages
 
     def _fallback_text(self) -> str:
-        noun, _, _ = self._nouns()
+        noun, _, past = self._nouns()
         buckets = self._buckets()
         total = len(self._records)
         overall = self.overall_status()
         name = self._display_name()
         if overall == "done":
-            return f"{noun} {name}: complete — {total} definitions succeeded"
+            ok, skipped = self._outcome_counts(buckets)
+            text = f"{noun} {name}: complete — {ok} {past}"
+            if skipped:
+                text += f", {skipped} skipped"
+            return text
         if overall == "failed":
             failed = len(buckets["failed"])
             return f"{noun} {name}: failed — {failed} of {total} definitions errored"
@@ -899,7 +973,7 @@ class SlackStatusBoard:
         Non-forced calls drop the update on a 429 (the next flush resends the
         latest snapshot); forced (terminal) calls sleep and retry.
         """
-        attempts = 3 if force else 1
+        attempts = 5 if force else 1
         for attempt in range(attempts):
             try:
                 return method(**kwargs)
@@ -914,7 +988,12 @@ class SlackStatusBoard:
                 self._next_update_at = time.monotonic() + max(
                     retry_after, self._config.update_interval
                 )
-                log.warn(f"Slack rate limited; deferring update {retry_after}s")
+                if force:
+                    # a forced flush is usually the run's last; there is no
+                    # later call to pick up the deferral
+                    log.error("Slack rate limited; final status update was dropped")
+                else:
+                    log.warn(f"Slack rate limited; deferring update {retry_after}s")
                 return None
         return None
 
@@ -927,16 +1006,23 @@ class SlackStatusBoard:
         not changed are not re-sent.
         """
         with self._lock:
-            if not self._records:
-                return
             now = time.monotonic()
-            if not force and now < self._next_update_at:
+            # skip when debounced or another thread is mid-flush; its snapshot
+            # is stale but the next flush resends the latest state
+            if not force and (now < self._next_update_at or self._sending):
                 return
+            self._sending = True
             self._seq += 1
             fallback = self._fallback_text()
-
-            # 1) Channel message — the thread root.
+            final = self.overall_status() != "in_progress"
             main_blocks = self._build_main_blocks()
+            thread_messages = self._build_thread_messages()
+
+        # Slack calls happen outside the state lock so worker threads marking
+        # progress during parallel init are never blocked on network I/O;
+        # _sending keeps senders (and the message-tracking fields) exclusive.
+        try:
+            # 1) Channel message — the thread root.
             try:
                 if self._ts is None:
                     resp = self._call_api(
@@ -950,9 +1036,8 @@ class SlackStatusBoard:
                         self._ts = resp["ts"]
                         self._channel = resp["channel"]
                         self._main_sent = self._normalize_for_compare(main_blocks)
-                elif (
-                    self._normalize_for_compare(main_blocks) != self._main_sent
-                    or self.overall_status() != "in_progress"
+                elif self._normalize_for_compare(main_blocks) != self._main_sent or (
+                    final
                 ):
                     resp = self._call_api(
                         client.chat_update,
@@ -967,12 +1052,8 @@ class SlackStatusBoard:
             except Exception as e:
                 log.error(f"Slack API error updating run message: {e}")
 
-            # Without a channel message there is no thread; try again next call.
-            if self._ts is None:
-                return
-
-            # 2) Threaded per-definition table.
-            for i, blocks in enumerate(self._build_thread_messages()):
+            # 2) Threaded per-definition table (needs the thread root).
+            for i, blocks in enumerate(thread_messages if self._ts else []):
                 try:
                     if i < len(self._thread_ts):
                         if (
@@ -1006,12 +1087,16 @@ class SlackStatusBoard:
                             self._thread_sent.append(blocks)
                 except Exception as e:
                     log.error(f"Slack API error updating detail message {i + 1}: {e}")
-
-            # max() preserves a longer deferral set by a 429 Retry-After
-            self._next_update_at = max(
-                self._next_update_at,
-                time.monotonic() + self._config.update_interval,
-            )
+        finally:
+            with self._lock:
+                self._sending = False
+                # max() preserves a longer deferral set by a 429 Retry-After;
+                # advancing even on failure keeps the debounce engaged so a
+                # broken channel/token cannot turn every event into a retry
+                self._next_update_at = max(
+                    self._next_update_at,
+                    time.monotonic() + self._config.update_interval,
+                )
 
 
 @HandlerRegistry.register("slack")
@@ -1084,14 +1169,7 @@ class SlackHandler(BaseHandler):
     ) -> None:
         """Finalize the board; resolve any unfinished statuses."""
         try:
-            for rec in self._board._records.values():
-                for action_val in self._board._expected_actions:
-                    if rec.statuses.get(action_val, "pending") in (
-                        "pending",
-                        "running",
-                    ):
-                        rec.statuses[action_val] = "skipped"
-
+            self._board.finalize()
             self._board.post_or_update(self._client, force=True)
         except Exception as e:
             log.error(f"SlackHandler.teardown error: {e}")
@@ -1105,36 +1183,41 @@ class SlackHandler(BaseHandler):
         working_dir: str,
         result: Union["TerraformResult", None] = None,
     ) -> None:
-        self._board.ensure_definition(definition.name, deployment, working_dir)
+        # never let status reporting take down the run: exec_handlers callers
+        # only catch HandlerError, so anything raised here would propagate
+        try:
+            self._board.ensure_definition(definition.name, deployment, working_dir)
 
-        if stage == TerraformStage.PRE:
-            self._board.mark(definition.name, action, "running")
-            self._board.post_or_update(self._client)
+            if stage == TerraformStage.PRE:
+                self._board.mark(definition.name, action, "running")
+                self._board.post_or_update(self._client)
 
-        elif stage == TerraformStage.POST:
-            if result is None:
-                status = "failed"
-            elif result.exit_code == 0:
-                status = "done"
-            elif action == TerraformAction.PLAN and result.exit_code == 2:
-                status = "changes"
-            else:
-                status = "failed"
-            self._board.mark(definition.name, action, status)
-            self._board.record_result(
-                definition.name, action, result, failed=(status == "failed")
-            )
-            # a clean plan with no changes means apply will be skipped; mark it
-            # now so finished counts stay accurate during the run
-            if (
-                action == TerraformAction.PLAN
-                and status == "done"
-                and "apply" in self._board._expected_actions
-            ):
-                self._board.mark(definition.name, TerraformAction.APPLY, "skipped")
-            self._board.post_or_update(self._client)
+            elif stage == TerraformStage.POST:
+                if result is None:
+                    status = "failed"
+                elif result.exit_code == 0:
+                    status = "done"
+                elif action == TerraformAction.PLAN and result.exit_code == 2:
+                    status = "changes"
+                else:
+                    status = "failed"
+                self._board.mark(definition.name, action, status)
+                self._board.record_result(
+                    definition.name, action, result, failed=(status == "failed")
+                )
+                # a clean plan with no changes means apply will be skipped; mark
+                # it now so finished counts stay accurate during the run
+                if (
+                    action == TerraformAction.PLAN
+                    and status == "done"
+                    and self._board.expects(TerraformAction.APPLY)
+                ):
+                    self._board.mark(definition.name, TerraformAction.APPLY, "skipped")
+                self._board.post_or_update(self._client)
 
-        elif stage == TerraformStage.ERROR:
-            self._board.mark(definition.name, action, "failed")
-            self._board.record_result(definition.name, action, result, failed=True)
-            self._board.post_or_update(self._client)
+            elif stage == TerraformStage.ERROR:
+                self._board.mark(definition.name, action, "failed")
+                self._board.record_result(definition.name, action, result, failed=True)
+                self._board.post_or_update(self._client)
+        except Exception as e:
+            log.error(f"SlackHandler.execute error: {e}")

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -71,6 +71,9 @@ class SlackStatusBoard:
         "skipped": "—",
     }
     ACTION_ORDER: list[str] = ["init", "plan", "apply", "destroy"]
+    # Slack allows at most 50 blocks per message; keep detail rows well under it.
+    MAX_BLOCKS: int = 50
+    DETAIL_ROWS_PER_MSG: int = 45
 
     def __init__(self, channel: str, title: str | None, run_id: str | None):
         self._ts: str | None = None
@@ -81,6 +84,12 @@ class SlackStatusBoard:
         self._run_id = run_id
         self._title = title
         self._git_context: str | None = None
+        # Parent (summary) message ts is `_ts`; threaded detail messages are
+        # `_detail_ts`. We cache the last blocks sent for each so repeated
+        # post_or_update calls skip no-op Slack updates.
+        self._detail_ts: list[str] = []
+        self._parent_blocks_sent: Union[list, None] = None
+        self._detail_blocks_sent: list[list] = []
 
     def ensure_definition(
         self, definition_name: str, deployment: str, working_dir: str
@@ -183,11 +192,35 @@ class SlackStatusBoard:
             parts.append(f"Commit: {commit}")
         return "  ".join(parts) if parts else None
 
-    def _build_blocks(self) -> list[dict]:
-        """Build Slack Block Kit payload for the current status board state."""
+    def _status_counts(self) -> dict[str, int]:
+        """Count definition+action pairs by status across all seen actions."""
+        counts: dict[str, int] = {}
+        for action_statuses in self._statuses.values():
+            for action_val in self._seen_actions:
+                st = action_statuses.get(action_val, "pending")
+                counts[st] = counts.get(st, 0) + 1
+        return counts
+
+    def _banner(self) -> str:
+        """Overall status banner text."""
+        overall = self.overall_status()
+        if overall == "in_progress":
+            return "🟡  *In progress*"
+        if overall == "done":
+            skipped = self.skipped_count()
+            if skipped:
+                return f"✅  *Run complete — {skipped} action(s) skipped*"
+            return "✅  *Run complete — all definitions succeeded*"
+        return f"❌  *Run failed — {self.failed_count()} action(s) errored*"
+
+    def _build_summary_blocks(self) -> list[dict]:
+        """Compact parent-message blocks: header, git context, banner, counts.
+
+        Kept well under Slack's 50-block limit; the per-definition table lives in
+        threaded detail messages (see _build_detail_chunks).
+        """
         blocks: list[dict] = []
 
-        # Header block
         title = self._title or self._deployment or "Terraform run"
         header_text = f"🏗️  {title}"
         if self._run_id:
@@ -199,7 +232,6 @@ class SlackStatusBoard:
             }
         )
 
-        # Git context block (omitted when unavailable)
         if self._git_context:
             blocks.append(
                 {
@@ -208,19 +240,64 @@ class SlackStatusBoard:
                 }
             )
 
-        # Status table using 2-column fields layout (left = name, right = emoji row)
-        if self._seen_actions and self._statuses:
-            action_labels = "  ".join(f"*{a.capitalize()}*" for a in self._seen_actions)
-            blocks.append(
-                {
-                    "type": "section",
-                    "fields": [
-                        {"type": "mrkdwn", "text": "*Definition*"},
-                        {"type": "mrkdwn", "text": action_labels},
-                    ],
-                }
-            )
-            for def_name, action_statuses in self._statuses.items():
+        blocks.append(
+            {"type": "section", "text": {"type": "mrkdwn", "text": self._banner()}}
+        )
+
+        counts = self._status_counts()
+        order = [
+            ("running", "🔄"),
+            ("pending", "⏳"),
+            ("changes", "🔵"),
+            ("done", "✅"),
+            ("failed", "❌"),
+            ("skipped", "—"),
+        ]
+        tallies = "  ".join(f"{emoji} {counts[k]}" for k, emoji in order if counts.get(k))
+        summary = f"*{len(self._statuses)}* definition(s)"
+        if tallies:
+            summary += f"   |   {tallies}"
+        summary += "   ·   🧵 per-definition status in thread"
+        blocks.append(
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": summary}]}
+        )
+
+        return blocks
+
+    def _build_detail_chunks(self) -> list[list[dict]]:
+        """Per-definition status table, split into thread messages under the block limit.
+
+        Each chunk is one threaded message: a context header + the column header +
+        up to DETAIL_ROWS_PER_MSG definition rows (<= MAX_BLOCKS blocks total).
+        """
+        if not (self._seen_actions and self._statuses):
+            return []
+
+        action_labels = "  ".join(f"*{a.capitalize()}*" for a in self._seen_actions)
+        header_field = {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": "*Definition*"},
+                {"type": "mrkdwn", "text": action_labels},
+            ],
+        }
+
+        items = list(self._statuses.items())
+        total = len(items)
+        rows = self.DETAIL_ROWS_PER_MSG
+        n_chunks = max(1, (total + rows - 1) // rows)
+
+        chunks: list[list[dict]] = []
+        for i in range(n_chunks):
+            start, end = i * rows, min((i + 1) * rows, total)
+            label = f"Definitions {start + 1}–{end} of {total}"
+            if n_chunks > 1:
+                label += f"   (part {i + 1}/{n_chunks})"
+            blocks: list[dict] = [
+                {"type": "context", "elements": [{"type": "mrkdwn", "text": label}]},
+                header_field,
+            ]
+            for def_name, action_statuses in items[start:end]:
                 emoji_row = "  ".join(
                     self.STATUS_EMOJI.get(
                         action_statuses.get(action_val, "pending"), "❓"
@@ -236,49 +313,73 @@ class SlackStatusBoard:
                         ],
                     }
                 )
-
-        # Divider
-        blocks.append({"type": "divider"})
-
-        # Overall status banner
-        overall = self.overall_status()
-        if overall == "in_progress":
-            banner = "🟡  *In progress*"
-        elif overall == "done":
-            skipped = self.skipped_count()
-            if skipped:
-                banner = f"✅  *Run complete — {skipped} action(s) skipped*"
-            else:
-                banner = "✅  *Run complete — all definitions succeeded*"
-        else:
-            failed = self.failed_count()
-            banner = f"❌  *Run failed — {failed} action(s) errored*"
-        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": banner}})
-
-        return blocks
+            chunks.append(blocks)
+        return chunks
 
     def post_or_update(self, client: WebClient) -> None:
-        """Post the status board as a new message, or update the existing one."""
-        blocks = self._build_blocks()
+        """Post/refresh the parent summary message and its threaded detail messages.
+
+        The board is split across messages to stay under Slack's 50-block limit:
+        a compact parent (summary) message is the thread root, and the
+        per-definition table is posted as one or more threaded replies. Messages
+        whose blocks haven't changed since the last call are not re-sent.
+        """
         fallback_text = f"Terraform run: {self._deployment or 'unknown'}"
+
+        # 1) Parent (summary) message — the thread root.
+        summary_blocks = self._build_summary_blocks()
         try:
             if self._ts is None:
                 resp = client.chat_postMessage(
-                    channel=self._channel,
-                    blocks=blocks,
-                    text=fallback_text,
+                    channel=self._channel, blocks=summary_blocks, text=fallback_text
                 )
                 self._ts = resp["ts"]
                 self._channel = resp["channel"]
-            else:
+                self._parent_blocks_sent = summary_blocks
+            elif summary_blocks != self._parent_blocks_sent:
                 client.chat_update(
                     channel=self._channel,
                     ts=self._ts,
-                    blocks=blocks,
+                    blocks=summary_blocks,
                     text=fallback_text,
                 )
+                self._parent_blocks_sent = summary_blocks
         except Exception as e:
-            log.error(f"Slack API error in post_or_update: {e}")
+            log.error(f"Slack API error updating summary message: {e}")
+
+        # Without a parent message we can't create the thread; try again next call.
+        if self._ts is None:
+            return
+
+        # 2) Threaded detail messages, chunked under the block limit.
+        for i, blocks in enumerate(self._build_detail_chunks()):
+            try:
+                if i < len(self._detail_ts):
+                    if (
+                        i < len(self._detail_blocks_sent)
+                        and blocks == self._detail_blocks_sent[i]
+                    ):
+                        continue  # unchanged; skip the API call
+                    client.chat_update(
+                        channel=self._channel,
+                        ts=self._detail_ts[i],
+                        blocks=blocks,
+                        text=fallback_text,
+                    )
+                    while len(self._detail_blocks_sent) <= i:
+                        self._detail_blocks_sent.append(None)
+                    self._detail_blocks_sent[i] = blocks
+                else:
+                    resp = client.chat_postMessage(
+                        channel=self._channel,
+                        thread_ts=self._ts,
+                        blocks=blocks,
+                        text=fallback_text,
+                    )
+                    self._detail_ts.append(resp["ts"])
+                    self._detail_blocks_sent.append(blocks)
+            except Exception as e:
+                log.error(f"Slack API error updating detail message {i + 1}: {e}")
 
 
 @HandlerRegistry.register("slack")

--- a/tfworker/handlers/slack.py
+++ b/tfworker/handlers/slack.py
@@ -123,6 +123,7 @@ class DefinitionRecord:
 
     __slots__ = (
         "name",
+        "expected",
         "statuses",
         "started_at",
         "action_started",
@@ -136,6 +137,9 @@ class DefinitionRecord:
 
     def __init__(self, name: str) -> None:
         self.name = name
+        # actions this definition is expected to run; seeded from the run's
+        # expected actions, extended per definition (e.g. always_apply)
+        self.expected: list[str] = []
         self.statuses: dict[str, str] = {}
         self.started_at: float | None = None
         self.action_started: dict[str, float] = {}
@@ -232,7 +236,25 @@ class SlackStatusBoard:
                 self._deployment = deployment
                 self._resolve_git_context(working_dir)
             if definition_name not in self._records:
-                self._records[definition_name] = DefinitionRecord(definition_name)
+                rec = DefinitionRecord(definition_name)
+                rec.expected = list(self._expected_actions)
+                self._records[definition_name] = rec
+
+    def add_definition_action(
+        self, definition_name: str, action: TerraformAction
+    ) -> None:
+        """Expect an extra action for one definition (e.g. always_apply).
+
+        Kept per definition rather than run-wide: one always_apply definition
+        must not make a plan-only run present as an apply, nor give every
+        other definition an apply expectation it can never satisfy.
+        """
+        with self._lock:
+            rec = self._records[definition_name]
+            if action.value not in rec.expected:
+                rec.expected = [
+                    a for a in self.ACTION_ORDER if a in rec.expected + [action.value]
+                ]
 
     def set_expected_actions(self, actions: list[TerraformAction]) -> None:
         """Set the action columns for the run and derive the primary action."""
@@ -248,15 +270,15 @@ class SlackStatusBoard:
         """Update the status of a definition+action pair."""
         with self._lock:
             action_val = action.value
-            if action_val not in self._expected_actions:
-                self._expected_actions = [
-                    a
-                    for a in self.ACTION_ORDER
-                    if a in self._expected_actions + [action_val]
-                ]
             if definition_name not in self._records:
-                self._records[definition_name] = DefinitionRecord(definition_name)
+                rec = DefinitionRecord(definition_name)
+                rec.expected = list(self._expected_actions)
+                self._records[definition_name] = rec
             rec = self._records[definition_name]
+            if action_val not in rec.expected:
+                rec.expected = [
+                    a for a in self.ACTION_ORDER if a in rec.expected + [action_val]
+                ]
             rec.statuses[action_val] = status
             now = time.monotonic()
             if status == "running":
@@ -308,15 +330,16 @@ class SlackStatusBoard:
                         int(n) for n in _APPLY_COUNT_RE.findall(match.group(0))
                     )
 
-    def expects(self, action: TerraformAction) -> bool:
-        """Return True when the run is expected to perform the given action."""
-        return action.value in self._expected_actions
+    def expects(self, action: TerraformAction, definition_name: str) -> bool:
+        """Return True when the given definition is expected to run the action."""
+        rec = self._records.get(definition_name)
+        return rec is not None and action.value in rec.expected
 
     def finalize(self) -> None:
         """Resolve statuses left pending/running as skipped (run over or aborted)."""
         with self._lock:
             for rec in self._records.values():
-                for action_val in self._expected_actions:
+                for action_val in rec.expected:
                     if rec.statuses.get(action_val, "pending") in (
                         "pending",
                         "running",
@@ -384,7 +407,7 @@ class SlackStatusBoard:
         run resolved by teardown) — conflating them would misreport clean
         plans as not having run.
         """
-        vals = [rec.statuses.get(a, "pending") for a in self._expected_actions]
+        vals = [rec.statuses.get(a, "pending") for a in rec.expected]
         if "failed" in vals:
             return "failed"
         if "running" in vals:
@@ -393,7 +416,7 @@ class SlackStatusBoard:
             return "queued"
         if all(v == "skipped" for v in vals):
             return "skipped"
-        if "plan" in self._expected_actions and rec.statuses.get("plan") == "skipped":
+        if "plan" in rec.expected and rec.statuses.get("plan") == "skipped":
             return "skipped"
         if not rec.applied_changes and (
             rec.planned_changes == 0 or rec.statuses.get("apply") == "skipped"
@@ -879,10 +902,15 @@ class SlackStatusBoard:
             return []
 
         noun, _, _ = self._nouns()
-        header = [{"type": "raw_text", "text": "Definition"}]
-        header += [
-            {"type": "raw_text", "text": a.capitalize()} for a in self._expected_actions
+        # column per action any definition expects (always_apply can add an
+        # apply column to a plan-only run for just those definitions)
+        columns = [
+            a
+            for a in self.ACTION_ORDER
+            if any(a in r.expected for r in self._records.values())
         ]
+        header = [{"type": "raw_text", "text": "Definition"}]
+        header += [{"type": "raw_text", "text": a.capitalize()} for a in columns]
         header += [
             {"type": "raw_text", "text": "Changed"},
             {"type": "raw_text", "text": "Ran (s)"},
@@ -895,8 +923,13 @@ class SlackStatusBoard:
                     [{"type": "text", "text": rec.name, "style": {"code": True}}]
                 )
             ]
-            for action_val in self._expected_actions:
-                row.append(self._status_cell(rec.statuses.get(action_val, "pending")))
+            for action_val in columns:
+                if action_val not in rec.expected:
+                    row.append({"type": "raw_text", "text": "—"})
+                else:
+                    row.append(
+                        self._status_cell(rec.statuses.get(action_val, "pending"))
+                    )
             changed = (
                 rec.applied_changes
                 if rec.applied_changes is not None
@@ -1192,9 +1225,7 @@ class SlackHandler(BaseHandler):
                 terraform_options, "plan_destroy", False
             ):
                 expected_actions.append(TerraformAction.PLAN)
-            if getattr(terraform_options, "apply", False) or any(
-                getattr(defn, "always_apply", False) for defn in definitions.values()
-            ):
+            if getattr(terraform_options, "apply", False):
                 expected_actions.append(TerraformAction.APPLY)
             if getattr(terraform_options, "destroy", False):
                 expected_actions.append(TerraformAction.DESTROY)
@@ -1202,6 +1233,10 @@ class SlackHandler(BaseHandler):
             self._board.set_expected_actions(expected_actions)
             for defn in definitions.values():
                 self._board.ensure_definition(defn.name, deployment, working_dir)
+                # always_apply applies right after its plan even in plan-only
+                # runs — an expectation for this definition, not the whole run
+                if getattr(defn, "always_apply", False):
+                    self._board.add_definition_action(defn.name, TerraformAction.APPLY)
 
             self._board.post_or_update(self._client, force=True)
         except Exception as e:
@@ -1255,7 +1290,7 @@ class SlackHandler(BaseHandler):
                 if (
                     action == TerraformAction.PLAN
                     and status == "done"
-                    and self._board.expects(TerraformAction.APPLY)
+                    and self._board.expects(TerraformAction.APPLY, definition.name)
                 ):
                     self._board.mark(definition.name, TerraformAction.APPLY, "skipped")
                 self._board.post_or_update(self._client)

--- a/tfworker/util/hooks.py
+++ b/tfworker/util/hooks.py
@@ -374,6 +374,8 @@ def _populate_environment_with_terraform_remote_vars(
     """
     Populates the environment with Terraform variables.
 
+    Supports nested structures (dicts and lists) in addition to simple references.
+
     Args:
         local_env (Dict[str, str]): The environment variables.
         working_dir (str): The working directory of the Terraform definition.
@@ -386,15 +388,33 @@ def _populate_environment_with_terraform_remote_vars(
     with open(os.path.join(working_dir, WORKER_LOCALS_FILENAME)) as f:
         contents = f.read()
 
-    # I'm sorry. :-)
-    # this regex looks for variables in the form of:
-    # <var_name, ITEM> = data.terraform_remote_state.<the name of a remote definition, STATE>.outputs.<the name of an output, STATE_ITEM>
+    # Create a cache dict to avoid multiple backend calls for the same state
+    state_cache: Dict[str, Dict[str, Any]] = {}
+
+    # Try parsing with HCL2 for nested structures
+    try:
+        parsed = hcl2.loads(contents)
+        if "locals" in parsed and parsed["locals"]:
+            locals_block = parsed["locals"][0]
+            for var_name, var_value in locals_block.items():
+                resolved_value = _resolve_terraform_value(
+                    var_value, backend, state_cache
+                )
+                _set_hook_env_var(
+                    local_env,
+                    TFHookVarType.REMOTE,
+                    var_name,
+                    resolved_value,
+                    b64_encode,
+                )
+            return
+    except Exception as e:
+        log.debug(f"HCL2 parsing failed, falling back to regex: {e}")
+
+    # Fallback to legacy regex-based parsing for simple single-line references
     r = re.compile(
         r"\s*(?P<item>\w+)\s*\=.+data\.terraform_remote_state\.(?P<state>\w+)\.outputs\.(?P<state_item>\w+)\s*"
     )
-
-    # Create a cache dict to avoid multiple backend calls for the same state
-    state_cache: Dict[str, Dict[str, Any]] = {}
 
     for line in contents.splitlines():
         m = r.match(line)
@@ -413,22 +433,86 @@ def _populate_environment_with_terraform_remote_vars(
             )
 
             # Parse the Terraform output JSON to extract just the value field
-            # Terraform output format is: {"value": <actual_value>, "type": <type>, "sensitive": <bool>}
             try:
                 state_output = json.loads(state_value_json)
-                # Extract just the value field from the Terraform output structure
                 if isinstance(state_output, dict) and "value" in state_output:
                     state_value = state_output["value"]
                 else:
-                    # Fallback to the raw value if it's not in the expected format
                     state_value = state_value_json
             except (json.JSONDecodeError, TypeError):
-                # If parsing fails, use the raw value
                 state_value = state_value_json
 
             _set_hook_env_var(
                 local_env, TFHookVarType.REMOTE, item, state_value, b64_encode
             )
+
+
+def _resolve_terraform_value(
+    value: Any,
+    backend: "BaseBackend",
+    state_cache: Dict[str, Dict[str, Any]],
+) -> Any:
+    """
+    Recursively resolve Terraform remote state references to actual values.
+
+    Handles:
+    - Simple strings with terraform_remote_state references
+    - Nested dicts
+    - Lists
+    - Literal values
+
+    Args:
+        value: The value to resolve (str, dict, list, or literal)
+        backend: The backend instance to fetch state from
+        state_cache: Cache of already-fetched state data
+
+    Returns:
+        Resolved value with terraform_remote_state references replaced by actual values
+    """
+    from tfworker.util.remote_vars import parse_tf_reference
+
+    if isinstance(value, str):
+        # Check if it's a terraform_remote_state reference
+        if "data.terraform_remote_state" in value:
+            try:
+                # Extract state and output_key from the reference
+                state, output_key = parse_tf_reference(value)
+
+                # Get the state data
+                state_data = _get_or_fetch_state(state, backend, state_cache)
+                outputs = state_data.get("outputs", {})
+
+                if output_key is None:
+                    # Return entire outputs dict (all output values)
+                    return {k: v.get("value") for k, v in outputs.items()}
+                else:
+                    # Return specific output value
+                    if output_key not in outputs:
+                        raise HookError(
+                            f"Output '{output_key}' not found in state '{state}'"
+                        )
+                    return outputs[output_key].get("value")
+            except (ValueError, KeyError) as e:
+                log.warning(f"Failed to parse terraform reference '{value}': {e}")
+                return value
+        else:
+            # Plain string, return as-is
+            return value
+
+    elif isinstance(value, dict):
+        # Recursively resolve dict values
+        return {
+            k: _resolve_terraform_value(v, backend, state_cache)
+            for k, v in value.items()
+        }
+
+    elif isinstance(value, list):
+        # Recursively resolve list items
+        return [_resolve_terraform_value(item, backend, state_cache) for item in value]
+
+    else:
+        # Literal value (int, bool, etc.), return as-is
+        return value
 
 
 def _populate_environment_with_extra_vars(
@@ -483,7 +567,9 @@ def _set_hook_env_var(
 
         # Base64-encode and store as a string to satisfy env type requirements
         encoded = base64.b64encode(raw_bytes).decode()
-        local_env[f"{var_type}_{key.upper()}"] = encoded
+        var_name = f"{var_type}_{key.upper()}"
+        local_env[var_name] = encoded
+        _check_env_var_size(var_name, encoded, b64_encode=True)
         return
 
     # For non-base64 values, ensure we end up with a string and shell-escape it
@@ -504,7 +590,61 @@ def _set_hook_env_var(
     # Use shlex.quote to safely escape values for shell consumption by hooks
     value_escaped = shlex.quote(value_str)
 
-    local_env[f"{var_type}_{key.upper()}"] = value_escaped
+    var_name = f"{var_type}_{key.upper()}"
+    local_env[var_name] = value_escaped
+    _check_env_var_size(var_name, value_escaped, b64_encode=False)
+
+
+def _check_env_var_size(
+    var_name: str, var_value: str, b64_encode: bool = False
+) -> None:
+    """
+    Check environment variable size and warn if approaching or exceeding shell limits.
+
+    Different shells have different limits for environment variable sizes:
+    - bash: typically 128 KB (131072 bytes)
+    - zsh: typically 1 MB (1048576 bytes)
+    - sh/dash: typically 64 KB (65536 bytes)
+
+    Args:
+        var_name: The environment variable name
+        var_value: The environment variable value
+        b64_encode: Whether the value is base64 encoded
+    """
+    # Shell-specific limits (in bytes)
+    SHELL_LIMITS = {
+        "bash": 131072,  # 128 KB
+        "zsh": 1048576,  # 1 MB
+        "sh": 65536,  # 64 KB
+        "dash": 65536,  # 64 KB
+    }
+
+    var_size = len(var_value.encode("utf-8"))
+
+    # Determine the current shell from SHELL environment variable
+    current_shell = os.environ.get("SHELL", "").split("/")[-1] or "sh"
+    limit = SHELL_LIMITS.get(
+        current_shell, SHELL_LIMITS["sh"]
+    )  # Default to sh (most conservative)
+
+    # Calculate warning threshold (80% of limit)
+    warning_threshold = int(limit * 0.8)
+
+    if var_size > limit:
+        encoding_note = " (base64 encoded)" if b64_encode else ""
+        log.warn(
+            f"Environment variable {var_name} is {var_size:,} bytes{encoding_note}, "
+            f"which exceeds the typical {current_shell} limit of {limit:,} bytes. "
+            f"This may cause issues in hook scripts. "
+            f"Consider using --b64-encode-hook-values or restructuring the data."
+        )
+    elif var_size > warning_threshold:
+        encoding_note = " (base64 encoded)" if b64_encode else ""
+        log.info(
+            f"Environment variable {var_name} is {var_size:,} bytes{encoding_note}, "
+            f"approaching the {current_shell} limit of {limit:,} bytes "
+            f"({var_size * 100 // limit}% of limit)."
+        )
 
 
 def _execute_hook_script(

--- a/tfworker/util/remote_vars.py
+++ b/tfworker/util/remote_vars.py
@@ -1,0 +1,291 @@
+"""Utilities for parsing and processing remote_vars configurations."""
+
+import re
+from typing import Any, Dict, List, Set, Tuple, Union
+
+# Type alias for remote_vars values
+RemoteVarValue = Union[str, Dict[str, Any], List[Any]]
+
+
+def parse_remote_var_reference(value: str) -> Tuple[str, str | None]:
+    """
+    Parse a remote var reference into state name and optional output key path.
+
+    Supports multiple formats:
+    - "state.outputs" -> entire outputs dict from state
+    - "state.outputs.key" -> specific output key from state
+    - "state.outputs.key.nested" -> nested key with dot notation
+    - "state.outputs.key["index"]" -> key with bracket notation
+    - "state.outputs.key.nested["index"]" -> mixed notation
+
+    Args:
+        value: Remote var reference string (e.g., "network1.outputs.vpc_id")
+
+    Returns:
+        Tuple of (state_name, output_key_path_or_None)
+        - If output_key_path is None, the entire outputs dict is requested
+        - If output_key_path is present, it's the path to the output (may include nested keys)
+
+    Raises:
+        ValueError: If the reference format is invalid
+
+    Examples:
+        >>> parse_remote_var_reference("network1.outputs")
+        ('network1', None)
+
+        >>> parse_remote_var_reference("network1.outputs.vpc_id")
+        ('network1', 'vpc_id')
+
+        >>> parse_remote_var_reference("network1.outputs.data.nested_key")
+        ('network1', 'data.nested_key')
+
+        >>> parse_remote_var_reference("network1.outputs.items[\"test_key\"]")
+        ('network1', 'items["test_key"]')
+    """
+    # Split on '.outputs' to separate state from key path
+    if ".outputs" not in value:
+        raise ValueError(
+            f"Invalid remote var reference: '{value}'. "
+            f"Expected format: 'state.outputs[.key.path]' or 'state.outputs[\"key\"]'"
+        )
+
+    parts = value.split(".outputs", 1)
+    state = parts[0]
+    key_path = parts[1] if len(parts) > 1 else ""
+
+    # Validate state name (must be word characters only)
+    if not re.match(r"^\w+$", state):
+        raise ValueError(
+            f"Invalid remote var reference: '{value}'. "
+            f"State name must contain only alphanumeric characters and underscores."
+        )
+
+    # If there's a key path, validate it starts with . or [
+    if key_path:
+        if not key_path.startswith(".") and not key_path.startswith("["):
+            raise ValueError(
+                f"Invalid remote var reference: '{value}'. "
+                f"Key path after 'outputs' must start with '.' or '[', got: '{key_path}'"
+            )
+
+        # If using pure dot notation (no brackets), validate each segment
+        if "[" not in key_path:
+            # Remove leading '.'
+            clean_path = key_path[1:] if key_path.startswith(".") else key_path
+            # Split on dots and validate each segment
+            segments = clean_path.split(".")
+            for segment in segments:
+                if segment and not re.match(r"^\w+$", segment):
+                    raise ValueError(
+                        f"Invalid remote var reference: '{value}'. "
+                        f"When using dot notation, each key segment must contain only "
+                        f"alphanumeric characters and underscores. Invalid segment: '{segment}'. "
+                        f"Use bracket notation for keys with special characters: 'state.outputs[\"{segment}\"]'"
+                    )
+
+        # Remove leading '.' for consistency
+        if key_path.startswith("."):
+            key_path = key_path[1:]
+        return state, key_path
+    else:
+        return state, None
+
+
+def generate_tf_reference(value: str) -> str:
+    """
+    Convert a remote var reference to Terraform HCL data source syntax.
+
+    Args:
+        value: Remote var reference string (e.g., "network1.outputs.vpc_id")
+
+    Returns:
+        Terraform HCL reference string
+
+    Raises:
+        ValueError: If the reference format is invalid
+
+    Examples:
+        >>> generate_tf_reference("network1.outputs")
+        'data.terraform_remote_state.network1.outputs'
+
+        >>> generate_tf_reference("network1.outputs.vpc_id")
+        'data.terraform_remote_state.network1.outputs.vpc_id'
+
+        >>> generate_tf_reference("network1.outputs.data.nested_key")
+        'data.terraform_remote_state.network1.outputs.data.nested_key'
+
+        >>> generate_tf_reference("network1.outputs.items[\"test_key\"]")
+        'data.terraform_remote_state.network1.outputs.items["test_key"]'
+    """
+    state, key_path = parse_remote_var_reference(value)
+    base_ref = f"data.terraform_remote_state.{state}.outputs"
+    if key_path:
+        # If key_path starts with '[', don't add a dot
+        if key_path.startswith("["):
+            return f"{base_ref}{key_path}"
+        else:
+            return f"{base_ref}.{key_path}"
+    return base_ref
+
+
+def extract_remote_states(value: RemoteVarValue) -> Set[str]:
+    """
+    Recursively extract all remote state names from a remote_vars value.
+
+    Supports strings, dicts, and lists to handle complex nested structures.
+
+    Args:
+        value: A remote_vars value (string, dict, or list)
+
+    Returns:
+        Set of unique state names referenced in the value
+
+    Examples:
+        >>> extract_remote_states("network1.outputs.vpc_id")
+        {'network1'}
+
+        >>> extract_remote_states({"k1": "net1.outputs", "k2": "net2.outputs.vpc"})
+        {'net1', 'net2'}
+
+        >>> extract_remote_states(["net1.outputs", "net2.outputs.id"])
+        {'net1', 'net2'}
+
+        >>> extract_remote_states({
+        ...     "vpcs": {
+        ...         "platform": "net1.outputs",
+        ...         "payments": "net2.outputs.vpc"
+        ...     },
+        ...     "env": "env_info.outputs.environment"
+        ... })
+        {'net1', 'net2', 'env_info'}
+    """
+    states = set()
+
+    if isinstance(value, str):
+        # Simple string reference
+        state, _ = parse_remote_var_reference(value)
+        states.add(state)
+    elif isinstance(value, dict):
+        # Dict: recursively process all values
+        for v in value.values():
+            states.update(extract_remote_states(v))
+    elif isinstance(value, list):
+        # List: recursively process all items
+        for item in value:
+            states.update(extract_remote_states(item))
+
+    return states
+
+
+def parse_tf_reference(tf_ref: str) -> Tuple[str, str | None]:
+    """
+    Parse a Terraform remote state reference into state name and optional output key path.
+
+    This is the inverse of generate_tf_reference() - it parses Terraform HCL
+    references back into their components.
+
+    Args:
+        tf_ref: Terraform HCL reference (e.g., "data.terraform_remote_state.net1.outputs.vpc_id")
+
+    Returns:
+        Tuple of (state_name, output_key_path_or_None)
+
+    Raises:
+        ValueError: If the reference format is invalid
+
+    Examples:
+        >>> parse_tf_reference("data.terraform_remote_state.network1.outputs")
+        ('network1', None)
+
+        >>> parse_tf_reference("data.terraform_remote_state.network1.outputs.vpc_id")
+        ('network1', 'vpc_id')
+
+        >>> parse_tf_reference("data.terraform_remote_state.network1.outputs.data.nested_key")
+        ('network1', 'data.nested_key')
+
+        >>> parse_tf_reference("data.terraform_remote_state.network1.outputs.items[\"test_key\"]")
+        ('network1', 'items["test_key"]')
+    """
+    # Split on '.outputs' to separate the prefix from the key path
+    prefix = "data.terraform_remote_state."
+    if not tf_ref.startswith(prefix):
+        raise ValueError(
+            f"Invalid Terraform remote state reference: '{tf_ref}'. "
+            f"Expected format: 'data.terraform_remote_state.state.outputs[.key.path]'"
+        )
+
+    remainder = tf_ref[len(prefix) :]
+    if ".outputs" not in remainder:
+        raise ValueError(
+            f"Invalid Terraform remote state reference: '{tf_ref}'. "
+            f"Expected format: 'data.terraform_remote_state.state.outputs[.key.path]'"
+        )
+
+    parts = remainder.split(".outputs", 1)
+    state = parts[0]
+    key_path = parts[1] if len(parts) > 1 else ""
+
+    # Validate state name
+    if not re.match(r"^\w+$", state):
+        raise ValueError(
+            f"Invalid Terraform remote state reference: '{tf_ref}'. "
+            f"State name must contain only alphanumeric characters and underscores."
+        )
+
+    # Process key path
+    if key_path:
+        # Remove leading '.' if present
+        if key_path.startswith("."):
+            key_path = key_path[1:]
+        return state, key_path if key_path else None
+    else:
+        return state, None
+
+
+def validate_remote_vars(remote_vars: Dict[str, RemoteVarValue]) -> None:
+    """
+    Validate a remote_vars configuration dictionary.
+
+    Checks that all string references are properly formatted and recursively
+    validates nested structures.
+
+    Args:
+        remote_vars: Dictionary of remote variable configurations
+
+    Raises:
+        ValueError: If any reference is invalid
+
+    Examples:
+        >>> validate_remote_vars({"env": "env_info.outputs.environment"})
+        # No exception - valid
+
+        >>> validate_remote_vars({"bad": "invalid reference"})
+        Traceback (most recent call last):
+        ...
+        ValueError: Invalid remote var reference...
+    """
+    for key, value in remote_vars.items():
+        try:
+            _validate_value(value)
+        except ValueError as e:
+            raise ValueError(f"Invalid remote_vars configuration for key '{key}': {e}")
+
+
+def _validate_value(value: RemoteVarValue) -> None:
+    """Recursively validate a remote_vars value."""
+    if isinstance(value, str):
+        # Validate string reference format
+        parse_remote_var_reference(value)
+    elif isinstance(value, dict):
+        # Recursively validate dict values
+        for v in value.values():
+            _validate_value(v)
+    elif isinstance(value, list):
+        # Recursively validate list items
+        for item in value:
+            _validate_value(item)
+    else:
+        raise ValueError(
+            f"Unsupported remote_vars value type: {type(value).__name__}. "
+            f"Expected str, dict, or list."
+        )


### PR DESCRIPTION
This PR contains: 

- updated deps to address several dependabot alerts and stay current
- updates the AWS authenticator to ignore AWS_PROFILE when an access key ID and secret are set
- updates the remote_var structure to allow for creating structures from remote variables, for example: 
- includes Richard Simpsons refactored and improved slack scoreboard 